### PR TITLE
Analytic unit ID in tooltip instead of name #56

### DIFF
--- a/src/graph_tooltip.ts
+++ b/src/graph_tooltip.ts
@@ -204,7 +204,7 @@ export class GraphTooltip {
         <div class="graph-tooltip-list-item">
           <div class="graph-tooltip-series-name">
             <i class="fa fa-exclamation" style="color:${s.anomalyType.color}"></i>
-            ${s.anomalyType.id}:
+            ${s.anomalyType.name}:
           </div>
           <div class="graph-tooltip-value">
             <i class="fa ${ s.segment.labeled ? "fa-thumb-tack" : "fa-search-plus" }" aria-hidden="true"></i>


### PR DESCRIPTION
Fix for this issue: https://github.com/hastic/hastic-grafana-graph-panel/issues/56

replace AnalyticUnitId with AnalyticUnitName on graph tooltip.

![image](https://user-images.githubusercontent.com/22073083/44472918-e0d0ea00-a637-11e8-9946-c82a6c23d283.png)
