### PR TITLE
Get datasource type from Grafana API

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -187,14 +187,16 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.render(this.seriesList);
       this.$scope.$digest();
     });
+
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;
+
       this.datasourceRequest = {
         url: requestConfig.url,
-        type: requestConfig.inspect.type,
         method: requestConfig.method,
         data: requestConfig.data,
-        params: requestConfig.params
+        params: requestConfig.params,
+        type: undefined
       };
     });
 

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -15,6 +15,9 @@ export class AnalyticService {
     metric: MetricExpanded, datasourceRequest: DatasourceRequest, 
     newItem: AnalyticUnit, panelId: number
   ): Promise<AnalyticUnitId> {
+    let datasource = await this._backendSrv.get(`/api/datasources/name/${metric.datasource}`);
+    datasourceRequest.type = datasource.type;
+
     return this._backendSrv.post(
       this._backendURL + '/analyticUnits', 
       {


### PR DESCRIPTION
Closes https://github.com/hastic/hastic-grafana-graph-panel/issues/69
Closes https://github.com/hastic/hastic-grafana-graph-panel/issues/70

Get datasource type from Grafana API instead of `ds-request-response`