### PR TITLE
"Server is offline" error instead of "Unexpected error" #48

### DIFF
--- a/src/controllers/analytic_controller.ts
+++ b/src/controllers/analytic_controller.ts
@@ -402,6 +402,14 @@ export class AnalyticController {
     return this._serverInfo;
   }
 
+  public get serverStatus() {
+    return this._analyticService.isUp
+  }
+
+  public checkServerStatus() {
+    this._analyticService.isBackendOk();
+  }
+
 }
 
 function addAlphaToRGB(colorString: string, alpha: number): string {

--- a/src/controllers/analytic_controller.ts
+++ b/src/controllers/analytic_controller.ts
@@ -405,11 +405,6 @@ export class AnalyticController {
   public get serverStatus() {
     return this._analyticService.isUp
   }
-
-  public checkServerStatus() {
-    this._analyticService.isBackendOk();
-  }
-
 }
 
 function addAlphaToRGB(colorString: string, alpha: number): string {

--- a/src/controllers/analytic_controller.ts
+++ b/src/controllers/analytic_controller.ts
@@ -403,7 +403,7 @@ export class AnalyticController {
   }
 
   public get serverStatus() {
-    return this._analyticService.isUp
+    return this._analyticService.isUp;
   }
 }
 

--- a/src/controllers/analytic_controller.ts
+++ b/src/controllers/analytic_controller.ts
@@ -132,7 +132,7 @@ export class AnalyticController {
     });
 
     this.labelingAnomaly.saving = false;
-    
+
     var anomaly = this.labelingAnomaly;
     this.dropLabeling();
     this._runStatusWaiter(anomaly);
@@ -256,7 +256,7 @@ export class AnalyticController {
       }
 
       var rangeDist = +options.xaxis.max - +options.xaxis.min;
-      
+
       let labeledSegmentBorderColor = tinycolor(LABELED_SEGMENT_BORDER_COLOR).toRgbString();
       labeledSegmentBorderColor = addAlphaToRGB(labeledSegmentBorderColor, REGION_STROKE_ALPHA);
       let deletedSegmentFillColor = tinycolor(DELETED_SEGMENT_FILL_COLOR).toRgbString();

--- a/src/module.ts
+++ b/src/module.ts
@@ -26,7 +26,6 @@ const BACKEND_VARIABLE_NAME = 'HASTIC_SERVER_URL';
 
 class GraphCtrl extends MetricsPanelCtrl {
   static template = template;
-  private _lostConnection = true;
 
   analyticService: AnalyticService;
   hiddenSeries: any = {};
@@ -214,7 +213,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
     return this.templateSrv.index[BACKEND_VARIABLE_NAME].current.value;
   }
-  
+
   async runBackendConnectivityCheck() {
     if(this.backendURL === '' || this.backendURL === undefined) {
       this.alertSrv.set(
@@ -226,20 +225,18 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     let connected = await this.analyticService.isBackendOk();
-    if(connected && this._lostConnection) {
+    if(connected) {
       this.alertSrv.set(
         'Connected to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'success', 4000
       );
-      this._lostConnection = false;
     } else if(!connected) {
       this.alertSrv.set(
         'Can`t connect to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'warning', 4000
       );
-      this._lostConnection = true;
     }
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -26,8 +26,9 @@ const BACKEND_VARIABLE_NAME = 'HASTIC_SERVER_URL';
 
 class GraphCtrl extends MetricsPanelCtrl {
   static template = template;
+  private _lostConnection = true;
 
-  anomalyService: AnalyticService;
+  analyticService: AnalyticService;
   hiddenSeries: any = {};
   seriesList: any = [];
   dataList: any = [];
@@ -163,11 +164,11 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.processor = new DataProcessor(this.panel);
 
 
-    this.anomalyService = new AnalyticService(this.backendURL, $http, this.alertSrv);
+    this.analyticService = new AnalyticService(this.backendURL, $http, this.alertSrv);
 
     this.runBackendConnectivityCheck();
 
-    this.analyticsController = new AnalyticController(this.panel, this.anomalyService, this.events);
+    this.analyticsController = new AnalyticController(this.panel, this.analyticService, this.events);
     this.anomalyTypes = this.panel.anomalyTypes;
     keybindingSrv.bind('d', this.onDKey.bind(this));
 
@@ -224,8 +225,8 @@ class GraphCtrl extends MetricsPanelCtrl {
       return;
     }
 
-    let connected = await this.anomalyService.isBackendOk();
-    if (connected) {
+    let connected = await this.analyticService.isBackendOk();
+    if(connected && this._lostConnection) {
       this.alertSrv.set(
         'Connected to Hastic server',
         `Hastic server: "${this.backendURL}"`,

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,7 +16,6 @@ import { PanelInfo } from './models/info';
 import { axesEditorComponent } from './axes_editor';
 
 import { MetricsPanelCtrl, alertTab } from 'grafana/app/plugins/sdk';
-import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 import { appEvents } from 'grafana/app/core/core'
 import config from 'grafana/app/core/config';
 
@@ -164,7 +163,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.processor = new DataProcessor(this.panel);
 
 
-    this.anomalyService = new AnalyticService(this.backendURL, backendSrv as BackendSrv, $http, alertSrv);
+    this.anomalyService = new AnalyticService(this.backendURL, $http, this.alertSrv);
 
     this.runBackendConnectivityCheck();
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -26,7 +26,6 @@ const BACKEND_VARIABLE_NAME = 'HASTIC_SERVER_URL';
 
 
 class GraphCtrl extends MetricsPanelCtrl {
-  public lostConnection: boolean = true;
   static template = template;
 
   anomalyService: AnalyticService;
@@ -165,10 +164,9 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.processor = new DataProcessor(this.panel);
 
 
-    this.anomalyService = new AnalyticService(this.backendURL, backendSrv as BackendSrv, $http);
+    this.anomalyService = new AnalyticService(this.backendURL, backendSrv as BackendSrv, $http, alertSrv);
 
     this.runBackendConnectivityCheck();
-    setInterval(this.runBackendConnectivityCheck.bind(this), 1000);
 
     this.analyticsController = new AnalyticController(this.panel, this.anomalyService, this.events);
     this.anomalyTypes = this.panel.anomalyTypes;
@@ -228,20 +226,18 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     let connected = await this.anomalyService.isBackendOk();
-    if (connected && this.lostConnection) {
+    if (connected) {
       this.alertSrv.set(
         'Connected to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'success', 4000
       );
-      this.lostConnection = false;
     } else if(!connected) {
       this.alertSrv.set(
         'Can`t connect to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'warning', 4000
       );
-      this.lostConnection = true;
     }
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -231,12 +231,6 @@ class GraphCtrl extends MetricsPanelCtrl {
         `Hastic server: "${this.backendURL}"`,
         'success', 4000
       );
-    } else if(!connected) {
-      this.alertSrv.set(
-        'Can`t connect to Hastic server',
-        `Hastic server: "${this.backendURL}"`,
-        'warning', 4000
-      );
     }
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -26,6 +26,7 @@ const BACKEND_VARIABLE_NAME = 'HASTIC_SERVER_URL';
 
 
 class GraphCtrl extends MetricsPanelCtrl {
+  public lostConnection: boolean = true;
   static template = template;
 
   anomalyService: AnalyticService;
@@ -167,7 +168,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.anomalyService = new AnalyticService(this.backendURL, backendSrv as BackendSrv, $http);
 
     this.runBackendConnectivityCheck();
-    setInterval(this.runBackendConnectivityCheck.bind(this),100);
+    setInterval(this.runBackendConnectivityCheck.bind(this), 1000);
 
     this.analyticsController = new AnalyticController(this.panel, this.anomalyService, this.events);
     this.anomalyTypes = this.panel.anomalyTypes;
@@ -215,9 +216,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
     return this.templateSrv.index[BACKEND_VARIABLE_NAME].current.value;
   }
-
+  
   async runBackendConnectivityCheck() {
-    console.log(this.anomalyService.noConnection)
     if(this.backendURL === '' || this.backendURL === undefined) {
       this.alertSrv.set(
         `Dashboard variable $${BACKEND_VARIABLE_NAME} is missing`,
@@ -228,20 +228,20 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     let connected = await this.anomalyService.isBackendOk();
-    if (connected && this.anomalyService.noConnection) {
-      this.anomalyService.noConnection = false;
+    if (connected && this.lostConnection) {
       this.alertSrv.set(
         'Connected to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'success', 4000
       );
+      this.lostConnection = false;
     } else if(!connected) {
       this.alertSrv.set(
         'Can`t connect to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'warning', 4000
       );
-      this.anomalyService.noConnection = true;
+      this.lostConnection = true;
     }
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -232,12 +232,14 @@ class GraphCtrl extends MetricsPanelCtrl {
         `Hastic server: "${this.backendURL}"`,
         'success', 4000
       );
+      this._lostConnection = false;
     } else if(!connected) {
       this.alertSrv.set(
         'Can`t connect to Hastic server',
         `Hastic server: "${this.backendURL}"`,
         'warning', 4000
       );
+      this._lostConnection = true;
     }
   }
 

--- a/src/partials/tab_analytics.html
+++ b/src/partials/tab_analytics.html
@@ -1,148 +1,160 @@
-<h5> Analytic Units </h5>
-<div class="editor-row">
-  <div class="gf-form" ng-repeat="analyticUnit in ctrl.analyticsController.analyticUnits">
+<div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
+  <h1>Hastic server is not responding. Please start Hastic server.</h1>
+  <!--<button class="btn btn-inverse" ng-click="ctrl.runBackendConnectivityCheck()">
+    <i class="fa fa-plug"></i>
+    Reconnect to Hastic server
+  </button> -->
+</div>
 
-    <label class="gf-form-label width-4"> Name </label>
-    <input
-      type="text" class="gf-form-input max-width-15"
-      ng-model="analyticUnit.name"
-      ng-disabled="true"
-    >
+<div ng-if="ctrl.analyticsController.serverStatus === true">
+  <h5> Analytic Units </h5>
+  <div class="editor-row">
+    <div class="gf-form" ng-repeat="analyticUnit in ctrl.analyticsController.analyticUnits">
 
-    <label class="gf-form-label width-8"> Type </label>
-    <div class="gf-form-select-wrapper">
-      <select class="gf-form-input width-12"
-        ng-model="analyticUnit.type"
-        ng-options="type.value as type.name for type in ctrl.panel.analyticUnitTypes"
+      <label class="gf-form-label width-4"> Name </label>
+      <input
+        type="text" class="gf-form-input max-width-15"
+        ng-model="analyticUnit.name"
         ng-disabled="true"
+      >
+
+      <label class="gf-form-label width-8"> Type </label>
+      <div class="gf-form-select-wrapper">
+        <select class="gf-form-input width-12"
+          ng-model="analyticUnit.type"
+          ng-options="type.value as type.name for type in ctrl.panel.analyticUnitTypes"
+          ng-disabled="true"
+        />
+      </div>
+
+      <!--
+      <label class="gf-form-label width-6"> Confidence </label>
+      <input
+        type="number" class="gf-form-input width-5 ng-valid ng-scope ng-empty ng-dirty ng-valid-number ng-touched"
+        placeholder="auto" bs-tooltip="'Override automatic decimal precision for legend and tooltips'"
+        data-placement="right" ng-model="ctrl.panel.decimals" ng-change="ctrl.render()" ng-model-onblur="" data-original-title="" title=""
       />
+      -->
+
+      <label class="gf-form-label width-6"> Color </label>
+      <span class="gf-form-label">
+        <color-picker
+          color="analyticUnit.color"
+          onChange="ctrl.onColorChange.bind(ctrl, analyticUnit.id)"
+        />
+      </span>
+
+      <label class="gf-form-label" ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }">
+        <a class="pointer" tabindex="1"
+          ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
+          ng-disabled="analyticUnit.status === 'LEARNING'"
+        >
+          <i class="fa fa-bar-chart" ng-if="!analyticUnit.saving"></i>
+          <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
+          <b ng-if="analyticUnit.selected && !analyticUnit.deleteMode && !analyticUnit.saving"> labeling </b>
+          <b ng-if="analyticUnit.selected && analyticUnit.deleteMode && !analyticUnit.saving"> deleting </b>
+          <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
+        </a>
+      </label>
+
+
+      <!-- <label class="gf-form-label"> Alerts: </label>
+      <label
+        class="gf-form-label text-center"
+        style="width: 4rem"
+        ng-if="analyticUnit.alertEnabled === undefined"
+        bs-tooltip="'Alarting status isn`t available. Wait please.'"
+      >
+        <i class="fa fa-spinner fa-spin"></i>
+      </label> -->
+
+      <gf-form-switch
+        ng-if="analyticUnit.alertEnabled !== undefined"
+        on-change="ctrl.onAnomalyAlertChange(analyticUnit)"
+        checked="analyticUnit.alertEnabled"
+        style="height: 36px;"
+      />
+
+      <label class="gf-form-label">
+        <a
+          ng-if="analyticUnit.visible"
+          ng-disabled="analyticUnit.selected"
+          bs-tooltip="'Hide. It`s visible now.'"
+          ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
+          class="pointer"
+        >
+          <i class="fa fa-eye"></i>
+        </a>
+
+        <a
+          ng-if="!analyticUnit.visible"
+          ng-disabled="analyticUnit.selected"
+          bs-tooltip="'Show. It`s hidden now.'"
+          ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
+          class="pointer"
+        >
+          <i class="fa fa-eye-slash"></i>
+        </a>
+      </label>
+
+      <label class="gf-form-label">
+        <a
+          ng-if="!analyticUnit.selected"
+          ng-click="ctrl.onRemove(analyticUnit.id)"
+          class="pointer"
+        >
+          <i class="fa fa-trash"></i>
+        </a>
+
+        <a
+          ng-if="analyticUnit.selected"
+          ng-click="ctrl.onCancelLabeling(analyticUnit.id)"
+          class="pointer"
+        >
+          <i class="fa fa-ban"></i>
+        </a>
+      </label>
+
+      <label>
+        <i ng-if="analyticUnit.status === 'LEARNING'" class="grafana-tip fa fa-leanpub ng-scope" bs-tooltip="'Learning'"></i>
+        <i ng-if="analyticUnit.status === 'PENDING'" class="grafana-tip fa fa-list-ul ng-scope" bs-tooltip="'Pending'"></i>
+        <i ng-if="analyticUnit.status === 'FAILED'" class="grafana-tip fa fa-exclamation-circle ng-scope" bs-tooltip="'Error: ' + analyticUnit.error"></i>
+      </label>
+
     </div>
+  </div>
 
-    <!--
-    <label class="gf-form-label width-6"> Confidence </label>
-    <input
-      type="number" class="gf-form-input width-5 ng-valid ng-scope ng-empty ng-dirty ng-valid-number ng-touched"
-      placeholder="auto" bs-tooltip="'Override automatic decimal precision for legend and tooltips'"
-      data-placement="right" ng-model="ctrl.panel.decimals" ng-change="ctrl.render()" ng-model-onblur="" data-original-title="" title=""
-    />
-    -->
-
-    <label class="gf-form-label width-6"> Color </label>
-    <span class="gf-form-label">
-      <color-picker
-        color="analyticUnit.color"
-        onChange="ctrl.onColorChange.bind(ctrl, analyticUnit.id)"
-      />
-    </span>
-
-    <label class="gf-form-label" ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }">
-      <a class="pointer" tabindex="1"
-        ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
-        ng-disabled="analyticUnit.status === 'LEARNING'"
+  <div class="editor-row" ng-if="ctrl.analyticsController.creatingNew">
+    <div class="gf-form">
+      <label class="gf-form-label width-4"> Name </label>
+      <input
+        type="text" class="gf-form-input max-width-15"
+        ng-model="ctrl.analyticsController.newAnalyticUnit.name"
       >
-        <i class="fa fa-bar-chart" ng-if="!analyticUnit.saving"></i>
-        <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
-        <b ng-if="analyticUnit.selected && !analyticUnit.deleteMode && !analyticUnit.saving"> labeling </b>
-        <b ng-if="analyticUnit.selected && analyticUnit.deleteMode && !analyticUnit.saving"> deleting </b>
-        <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
-      </a>
-    </label>
 
+      <label class="gf-form-label width-8"> Type </label>
+      <div class="gf-form-select-wrapper">
+        <select class="gf-form-input width-12"
+          ng-model="ctrl.analyticsController.newAnalyticUnit.type"
+          ng-options="type.value as type.name for type in ctrl.panel.analyticUnitTypes"
+        />
+      </div>
 
-    <!-- <label class="gf-form-label"> Alerts: </label>
-    <label
-      class="gf-form-label text-center"
-      style="width: 4rem"
-      ng-if="analyticUnit.alertEnabled === undefined"
-      bs-tooltip="'Alarting status isn`t available. Wait please.'"
-    >
-      <i class="fa fa-spinner fa-spin"></i>
-    </label> -->
+      <label class="gf-form-label">
+        <a class="pointer" tabindex="1" ng-click="ctrl.saveNew()">
+          <b ng-if="!ctrl.analyticsController.saving"> create </b>
+          <b ng-if="ctrl.analyticsController.saving" ng-disabled="true"> saving... </b>
+        </a>
+      </label>
+    </div>
+  </div>
 
-    <gf-form-switch
-      ng-if="analyticUnit.alertEnabled !== undefined"
-      on-change="ctrl.onAnomalyAlertChange(analyticUnit)"
-      checked="analyticUnit.alertEnabled"
-      style="height: 36px;"
-    />
-
-    <label class="gf-form-label">
-      <a
-        ng-if="analyticUnit.visible"
-        ng-disabled="analyticUnit.selected"
-        bs-tooltip="'Hide. It`s visible now.'"
-        ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
-        class="pointer"
-      >
-        <i class="fa fa-eye"></i>
-      </a>
-
-      <a
-        ng-if="!analyticUnit.visible"
-        ng-disabled="analyticUnit.selected"
-        bs-tooltip="'Show. It`s hidden now.'"
-        ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
-        class="pointer"
-      >
-        <i class="fa fa-eye-slash"></i>
-      </a>
-    </label>
-
-    <label class="gf-form-label">
-      <a
-        ng-if="!analyticUnit.selected"
-        ng-click="ctrl.onRemove(analyticUnit.id)"
-        class="pointer"
-      >
-        <i class="fa fa-trash"></i>
-      </a>
-
-      <a
-        ng-if="analyticUnit.selected"
-        ng-click="ctrl.onCancelLabeling(analyticUnit.id)"
-        class="pointer"
-      >
-        <i class="fa fa-ban"></i>
-      </a>
-    </label>
-
-    <label>
-      <i ng-if="analyticUnit.status === 'LEARNING'" class="grafana-tip fa fa-leanpub ng-scope" bs-tooltip="'Learning'"></i>
-      <i ng-if="analyticUnit.status === 'PENDING'" class="grafana-tip fa fa-list-ul ng-scope" bs-tooltip="'Pending'"></i>
-      <i ng-if="analyticUnit.status === 'FAILED'" class="grafana-tip fa fa-exclamation-circle ng-scope" bs-tooltip="'Error: ' + analyticUnit.error"></i>
-    </label>
-
+  <div class="gf-form-button-row" ng-if="!ctrl.analyticsController.creatingAnalyticUnit">
+    <button class="btn btn-inverse" ng-click="ctrl.createNew()">
+      <i class="fa fa-plus"></i>
+      Add Analytic Unit
+    </button>
+    
   </div>
 </div>
 
-<div class="editor-row" ng-if="ctrl.analyticsController.creatingNew">
-  <div class="gf-form">
-    <label class="gf-form-label width-4"> Name </label>
-    <input
-      type="text" class="gf-form-input max-width-15"
-      ng-model="ctrl.analyticsController.newAnalyticUnit.name"
-    >
-
-    <label class="gf-form-label width-8"> Type </label>
-    <div class="gf-form-select-wrapper">
-      <select class="gf-form-input width-12"
-        ng-model="ctrl.analyticsController.newAnalyticUnit.type"
-        ng-options="type.value as type.name for type in ctrl.panel.analyticUnitTypes"
-      />
-    </div>
-
-    <label class="gf-form-label">
-      <a class="pointer" tabindex="1" ng-click="ctrl.saveNew()">
-        <b ng-if="!ctrl.analyticsController.saving"> create </b>
-        <b ng-if="ctrl.analyticsController.saving" ng-disabled="true"> saving... </b>
-      </a>
-    </label>
-  </div>
-</div>
-
-<div class="gf-form-button-row" ng-if="!ctrl.analyticsController.creatingAnalyticUnit">
-  <button class="btn btn-inverse" ng-click="ctrl.createNew()">
-    <i class="fa fa-plus"></i>
-    Add Analytic Unit
-  </button>
-</div>

--- a/src/partials/tab_analytics.html
+++ b/src/partials/tab_analytics.html
@@ -1,9 +1,5 @@
 <div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
   <h1>Hastic server is not responding. Please start Hastic server.</h1>
-  <!--<button class="btn btn-inverse" ng-click="ctrl.runBackendConnectivityCheck()">
-    <i class="fa fa-plug"></i>
-    Reconnect to Hastic server
-  </button> -->
 </div>
 
 <div ng-if="ctrl.analyticsController.serverStatus === true">

--- a/src/partials/tab_analytics.html
+++ b/src/partials/tab_analytics.html
@@ -1,4 +1,5 @@
 <div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
+  <h5>Hastic server at "{{ctrl.backendURL}}" is not available</h5>
   <button class="btn btn-inverse" ng-click="ctrl.runBackendConnectivityCheck()">
     <i class="fa fa-plug"></i>
     Reconnect to Hastic server

--- a/src/partials/tab_analytics.html
+++ b/src/partials/tab_analytics.html
@@ -1,5 +1,8 @@
 <div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
-  <h1>Hastic server is not responding. Please start Hastic server.</h1>
+  <button class="btn btn-inverse" ng-click="ctrl.runBackendConnectivityCheck()">
+    <i class="fa fa-plug"></i>
+    Reconnect to Hastic server
+  </button>
 </div>
 
 <div ng-if="ctrl.analyticsController.serverStatus === true">

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -149,7 +149,7 @@ export class AnalyticService {
       return response.data;
     } catch (error) {
       this.alertSrv.set(
-        'lost connection to Hastic server',
+        'No connection to Hastic server',
         `Hastic server: "${this._backendURL}"`,
         'warning', 4000
       );
@@ -165,7 +165,7 @@ export class AnalyticService {
       return response.data;
     } catch (error) {
       this.alertSrv.set(
-        'lost connection to Hastic server',
+        'No connection to Hastic server',
         `Hastic server: "${this._backendURL}"`,
         'warning', 4000
       );

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -181,7 +181,7 @@ export class AnalyticService {
       return response.data;
     } catch (error) {
       this.alertSrv.set(
-        'lost connection to Hastic server',
+        'No connection to Hastic server',
         `Hastic server: "${this._backendURL}"`,
         'warning', 4000
       );

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -7,7 +7,7 @@ import { ServerInfo } from '../models/info';
 
 
 export class AnalyticService {
-  private _isUp: boolean = false;
+  private _isUp = false;
 
   constructor(private _backendURL: string, private $http, private alertSrv) {
     this.isBackendOk();

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -90,7 +90,7 @@ export class AnalyticService {
       resolve => setTimeout(resolve, duration)
     );
 
-    while (true) {
+    while(true) {
       yield await statusCheck();
       await timeout();
     }
@@ -116,7 +116,7 @@ export class AnalyticService {
 
   async getServerInfo(): Promise<ServerInfo> {
     let data = await this.get(this._backendURL);
-    console.log(data)
+    console.log(data);
     return {
       nodeVersion: data.nodeVersion,
       packageVersion: data.packageVersion,
@@ -137,7 +137,7 @@ export class AnalyticService {
     } catch(error) {
       this.displayConnectionAlert();
       console.error(error);
-      this._isUp = false
+      this._isUp = false;
     } 
   }
 

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -134,13 +134,9 @@ export class AnalyticService {
       let response = await this.$http({ method: 'GET', url, params });
       this._isUp = true;
       return response.data;
-    } catch (error) {
-      this.alertSrv.set(
-        'No connection to Hastic server',
-        `Hastic server: "${this._backendURL}"`,
-        'warning', 4000
-      );
-      console.log(error);
+    } catch(error) {
+      this.displayConnectionAlert();
+      console.error(error);
       this._isUp = false
     } 
   }
@@ -150,13 +146,9 @@ export class AnalyticService {
       let response = await this.$http({ method: 'POST', url, data });
       this._isUp = true;
       return response.data;
-    } catch (error) {
-      this.alertSrv.set(
-        'No connection to Hastic server',
-        `Hastic server: "${this._backendURL}"`,
-        'warning', 4000
-      );
-      console.log(error);
+    } catch(error) {
+      this.displayConnectionAlert();
+      console.error(error);
       this._isUp = false;
     } 
   }
@@ -166,15 +158,19 @@ export class AnalyticService {
       let response = await this.$http({ method: 'PATCH', url, data });
       this._isUp = true;
       return response.data;
-    } catch (error) {
-      this.alertSrv.set(
-        'No connection to Hastic server',
-        `Hastic server: "${this._backendURL}"`,
-        'warning', 4000
-      );
-      console.log(error);
+    } catch(error) {
+      this.displayConnectionAlert();
+      console.error(error);
       this._isUp = false;
     }
+  }
+
+  private displayConnectionAlert() {
+    this.alertSrv.set(
+      'No connection to Hastic server',
+      `Hastic server: "${this._backendURL}"`,
+      'warning', 4000
+    );
   }
 
   public get isUp() {

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -9,7 +9,7 @@ import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 
 
 export class AnalyticService {
-  public isUp: boolean = false;
+  private _isUp: boolean = false;
 
   constructor(private _backendURL: string, private _backendSrv: BackendSrv, public $http, public alertSrv) {
     this.isBackendOk();
@@ -37,15 +37,15 @@ export class AnalyticService {
     try { 
       let response = await this.$http({ method: 'GET', url: this._backendURL }); 
       if(response.status !== -1) {
-        this.isUp = true;
+        this._isUp = true;
         return true;
       } else {
-        this.isUp = false;
+        this._isUp = false;
         return false;
       }
       // TODO: check version
     } catch(e) {
-      this.isUp = false;
+      this._isUp = false;
       return false;
     }
   }
@@ -145,7 +145,7 @@ export class AnalyticService {
   private async get(url, params?) {
     try {
       let response = await this.$http({ method: 'GET', url: url, params: params });
-      this.isUp = true;
+      this._isUp = true;
       return response.data;
     } catch (error) {
       this.alertSrv.set(
@@ -154,14 +154,14 @@ export class AnalyticService {
         'warning', 4000
       );
       console.log(error);
-      this.isUp = false
+      this._isUp = false
     } 
   }
 
   private async post(url, data) {
     try {
       let response = await this.$http({ method: 'POST', url: url, data: data });
-      this.isUp = true;
+      this._isUp = true;
       return response.data;
     } catch (error) {
       this.alertSrv.set(
@@ -170,14 +170,14 @@ export class AnalyticService {
         'warning', 4000
       );
       console.log(error);
-      this.isUp = false;
+      this._isUp = false;
     } 
   }
 
   private async patch(url, data) {
     try {
       let response = await this.$http({ method: 'PATCH', url: url, data: data });
-      this.isUp = true;
+      this._isUp = true;
       return response.data;
     } catch (error) {
       this.alertSrv.set(
@@ -186,7 +186,11 @@ export class AnalyticService {
         'warning', 4000
       );
       console.log(error);
-      this.isUp = false;
+      this._isUp = false;
     }
+  }
+
+  public get isUp() {
+    return this._isUp;
   }
 }

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -9,137 +9,157 @@ import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 
 
 export class AnalyticService {
-  constructor(private _backendURL: string, private _backendSrv: BackendSrv) {
+  public isUp: boolean = false;
+  public noConnection: boolean = true;
+
+  constructor(private _backendURL: string, private _backendSrv: BackendSrv, public $http) {
+    this.isBackendOk();
   }
 
   async postNewItem(
     metric: MetricExpanded, datasourceRequest: DatasourceRequest, 
     newItem: AnalyticUnit, panelId: number
   ): Promise<AnalyticUnitId> {
-    let datasource = await this._backendSrv.get(`/api/datasources/name/${metric.datasource}`);
-    datasourceRequest.type = datasource.type;
+    if(this.isUp) {
+      let datasource = await this._backendSrv.get(`/api/datasources/name/${metric.datasource}`);
+      datasourceRequest.type = datasource.type;
 
-    return this._backendSrv.post(
-      this._backendURL + '/analyticUnits', 
-      {
-        panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
-        type: newItem.type,
-        name: newItem.name,
-        metric: metric.toJSON(),
-        datasource: datasourceRequest
-      }
-    ).then(res => res.id as AnalyticUnitId);
+      return this._backendSrv.post(
+        this._backendURL + '/analyticUnits',
+        {
+          panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
+          type: newItem.type,
+          name: newItem.name,
+          metric: metric.toJSON(),
+          datasource: datasourceRequest
+        }
+      ).then(res => res.id as AnalyticUnitId);
+    }
   };
 
   async isBackendOk(): Promise<boolean> {
     try {
-      var data = await this._backendSrv.get(this._backendURL);
+      let response = await this.$http({ method: 'GET', url: this._backendURL });
+      if(response.status !== -1) {
+        this.isUp = true;
+        return true;
+      } else {
+        this.isUp = false;
+      }
       // TODO: check version
-      return true;
     } catch(e) {
+      this.isUp = false;
       return false;
     }
   }
-   
+
   async updateSegments(
     id: AnalyticUnitId, addedSegments: SegmentsSet<Segment>, removedSegments: SegmentsSet<Segment>
   ): Promise<SegmentId[]> {
+    if (this.isUp) {
+      const getJSONs = (segs: SegmentsSet<Segment>) => segs.getSegments().map(segment => ({
+        from: segment.from,
+        to: segment.to
+      }));
 
-    const getJSONs = (segs: SegmentsSet<Segment>) => segs.getSegments().map(segment => ({
-      from: segment.from,
-      to: segment.to
-    }));
+      var payload = {
+        id,
+        addedSegments: getJSONs(addedSegments),
+        removedSegments: removedSegments.getSegments().map(s => s.id)
+      };
 
-    var payload = {
-      id,
-      addedSegments: getJSONs(addedSegments),
-      removedSegments: removedSegments.getSegments().map(s => s.id)
-    };
+      var data = await this._backendSrv.patch(this._backendURL + '/segments', payload);
+      if (data.addedIds === undefined) {
+        throw new Error('Server didn`t send addedIds');
+      }
 
-    var data = await this._backendSrv.patch(this._backendURL + '/segments', payload);
-    if(data.addedIds === undefined) {
-      throw new Error('Server didn`t send addedIds');
+      return data.addedIds as SegmentId[];
     }
-
-    return data.addedIds as SegmentId[];
   }
 
   async getSegments(id: AnalyticUnitId, from?: number, to?: number): Promise<AnalyticSegment[]> {
-    if(id === undefined) {
-      throw new Error('id is undefined');
+    if(this.isUp) {
+      if (id === undefined) {
+        throw new Error('id is undefined');
+      }
+      var payload: any = { id };
+      if (from !== undefined) {
+        payload['from'] = from;
+      }
+      if (to !== undefined) {
+        payload['to'] = to;
+      }
+      var data = await this._backendSrv.get(this._backendURL + '/segments', payload);
+      if (data.segments === undefined) {
+        throw new Error('Server didn`t return segments array');
+      }
+      var segments = data.segments as { id: SegmentId, from: number, to: number, labeled: boolean, deleted: boolean }[];
+      return segments.map(s => new AnalyticSegment(s.labeled, s.id, s.from, s.to, s.deleted));
     }
-    var payload: any = { id };
-    if(from !== undefined) {
-      payload['from'] = from;
-    }
-    if(to !== undefined) {
-      payload['to'] = to;
-    }
-    var data = await this._backendSrv.get(this._backendURL + '/segments', payload);
-    if(data.segments === undefined) {
-      throw new Error('Server didn`t return segments array');
-    }
-    var segments = data.segments as { id: SegmentId, from: number, to: number, labeled: boolean, deleted: boolean }[];
-    return segments.map(s => new AnalyticSegment(s.labeled, s.id, s.from, s.to, s.deleted));
   }
 
   async * getStatusGenerator(id: AnalyticUnitId, duration: number) {
-    if(id === undefined) {
-      throw new Error('id is undefined');
-    }
-    let statusCheck = async () => {
-      var data = await this._backendSrv.get(
-        this._backendURL + '/analyticUnits/status', { id }
+    if(this.isUp) {
+      if (id === undefined) {
+        throw new Error('id is undefined');
+      }
+      let statusCheck = async () => {
+        var data = await this._backendSrv.get(
+          this._backendURL + '/analyticUnits/status', { id }
+        );
+        return data;
+      }
+
+      let timeout = async () => new Promise(
+        resolve => setTimeout(resolve, duration)
       );
-      return data;
-    }
 
-    let timeout = async () => new Promise(
-      resolve => setTimeout(resolve, duration)
-    );
-
-    while(true) {
-      yield await statusCheck();
-      await timeout();
+      while (true) {
+        yield await statusCheck();
+        await timeout();
+      }
     }
-    
   }
 
   async getAlertEnabled(id: AnalyticUnitId): Promise<boolean> {
-    if(id === undefined) {
-      throw new Error('id is undefined');
+    if(this.isUp) {
+      if (id === undefined) {
+        throw new Error('id is undefined');
+      }
+      var data = await this._backendSrv.get(
+        this._backendURL + '/alerts', { id }
+      );
+      if (data.enabled === undefined) {
+        throw new Error('Server didn`t return "enabled"');
+      }
+      return data.enabled as boolean;
     }
-    var data = await this._backendSrv.get(
-      this._backendURL + '/alerts', { id }
-    );
-    if(data.enabled === undefined) {
-      throw new Error('Server didn`t return "enabled"');
-    }
-    return data.enabled as boolean;
-
   }
 
   async setAlertEnabled(id: AnalyticUnitId, enabled: boolean): Promise<void> {
-    if(id === undefined) {
-      throw new Error('id is undefined');
+    if(this.isUp) {
+      if (id === undefined) {
+        throw new Error('id is undefined');
+      }
+      return this._backendSrv.post(
+        this._backendURL + '/alerts', { id, enabled }
+      );
     }
-    return this._backendSrv.post(
-      this._backendURL + '/alerts', { id, enabled }
-    );
   }
 
   async getServerInfo(): Promise<ServerInfo> {
-    let data = await this._backendSrv.get(this._backendURL);
-    return {
-      nodeVersion: data.nodeVersion,
-      packageVersion: data.packageVersion,
-      npmUserAgent: data.npmUserAgent,
-      docker: data.docker,
-      zmqConectionString: data.zmqConectionString,
-      serverPort: data.serverPort,
-      gitBranch: data.git.branch,
-      gitCommitHash: data.git.commitHash
-    };
+    if(this.isUp) {
+      let data = await this._backendSrv.get(this._backendURL);
+      return {
+        nodeVersion: data.nodeVersion,
+        packageVersion: data.packageVersion,
+        npmUserAgent: data.npmUserAgent,
+        docker: data.docker,
+        zmqConectionString: data.zmqConectionString,
+        serverPort: data.serverPort,
+        gitBranch: data.git.branch,
+        gitCommitHash: data.git.commitHash
+      };
+    }
   }
-
 }

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -17,19 +17,19 @@ export class AnalyticService {
     metric: MetricExpanded, datasourceRequest: DatasourceRequest, 
     newItem: AnalyticUnit, panelId: number
   ): Promise<AnalyticUnitId> {
-      let datasource = await this.get(`/api/datasources/name/${metric.datasource}`);
-      datasourceRequest.type = datasource.type;
+    let datasource = await this.get(`/api/datasources/name/${metric.datasource}`);
+    datasourceRequest.type = datasource.type;
 
-      const response = await this.post(this._backendURL + '/analyticUnits', {
-        panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
-        type: newItem.type,
-        name: newItem.name,
-        metric: metric.toJSON(),
-        datasource: datasourceRequest
-      });
-      
-      return response.id as AnalyticUnitId;
-    }
+    const response = await this.post(this._backendURL + '/analyticUnits', {
+      panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
+      type: newItem.type,
+      name: newItem.name,
+      metric: metric.toJSON(),
+      datasource: datasourceRequest
+    });
+    
+    return response.id as AnalyticUnitId;
+  }
 
   async isBackendOk(): Promise<boolean> {
     await this.get(this._backendURL);

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -20,32 +20,21 @@ export class AnalyticService {
       let datasource = await this.get(`/api/datasources/name/${metric.datasource}`);
       datasourceRequest.type = datasource.type;
 
-      return this.post(this._backendURL + '/analyticUnits', {
-          panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
-          type: newItem.type,
-          name: newItem.name,
-          metric: metric.toJSON(),
-          datasource: datasourceRequest
-        }
-      )
-        .then(res => res.id as AnalyticUnitId);
+      const response = await this.post(this._backendURL + '/analyticUnits', {
+        panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
+        type: newItem.type,
+        name: newItem.name,
+        metric: metric.toJSON(),
+        datasource: datasourceRequest
+      });
+      
+      return response.id as AnalyticUnitId;
     }
 
   async isBackendOk(): Promise<boolean> {
-    try { 
-      let response = await this.$http({ method: 'GET', url: this._backendURL }); 
-      if(response.status !== -1) {
-        this._isUp = true;
-        return true;
-      } else {
-        this._isUp = false;
-        return false;
-      }
-      // TODO: check version
-    } catch(e) {
-      this._isUp = false;
-      return false;
-    }
+    await this.get(this._backendURL);
+
+    return this._isUp;
   }
 
   async updateSegments(
@@ -63,25 +52,25 @@ export class AnalyticService {
     };
 
     var data = await this.patch(this._backendURL + '/segments', payload);
-    if (data.addedIds === undefined) {
+    if(data.addedIds === undefined) {
       throw new Error('Server didn`t send addedIds');
     }
     return data.addedIds as SegmentId[];
   }
 
   async getSegments(id: AnalyticUnitId, from?: number, to?: number): Promise<AnalyticSegment[]> {
-    if (id === undefined) {
+    if(id === undefined) {
       throw new Error('id is undefined');
     }
     var payload: any = { id };
-    if (from !== undefined) {
+    if(from !== undefined) {
       payload['from'] = from;
     }
-    if (to !== undefined) {
+    if(to !== undefined) {
       payload['to'] = to;
     }
     var data = await this.get(this._backendURL + '/segments', payload);
-    if (data.segments === undefined) {
+    if(data.segments === undefined) {
       throw new Error('Server didn`t return segments array');
     }
     var segments = data.segments as { id: SegmentId, from: number, to: number, labeled: boolean, deleted: boolean }[];
@@ -89,7 +78,7 @@ export class AnalyticService {
   }
 
   async * getStatusGenerator(id: AnalyticUnitId, duration: number) {
-    if (id === undefined) {
+    if(id === undefined) {
       throw new Error('id is undefined');
     }
     let statusCheck = async () => {
@@ -108,18 +97,18 @@ export class AnalyticService {
   }
 
   async getAlertEnabled(id: AnalyticUnitId): Promise<boolean> {
-    if (id === undefined) {
+    if(id === undefined) {
       throw new Error('id is undefined');
     }
     var data = await this.get(this._backendURL + '/alerts', { id });
-    if (data.enabled === undefined) {
+    if(data.enabled === undefined) {
       throw new Error('Server didn`t return "enabled"');
     }
     return data.enabled as boolean;
   }
 
   async setAlertEnabled(id: AnalyticUnitId, enabled: boolean): Promise<void> {
-    if (id === undefined) {
+    if(id === undefined) {
       throw new Error('id is undefined');
     }
     return await this.post(this._backendURL + '/alerts', { id, enabled });
@@ -142,7 +131,7 @@ export class AnalyticService {
 
   private async get(url, params?) {
     try {
-      let response = await this.$http({ method: 'GET', url: url, params: params });
+      let response = await this.$http({ method: 'GET', url, params });
       this._isUp = true;
       return response.data;
     } catch (error) {
@@ -158,7 +147,7 @@ export class AnalyticService {
 
   private async post(url, data) {
     try {
-      let response = await this.$http({ method: 'POST', url: url, data: data });
+      let response = await this.$http({ method: 'POST', url, data });
       this._isUp = true;
       return response.data;
     } catch (error) {
@@ -174,7 +163,7 @@ export class AnalyticService {
 
   private async patch(url, data) {
     try {
-      let response = await this.$http({ method: 'PATCH', url: url, data: data });
+      let response = await this.$http({ method: 'PATCH', url, data });
       this._isUp = true;
       return response.data;
     } catch (error) {

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -10,41 +10,39 @@ import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 
 export class AnalyticService {
   public isUp: boolean = false;
-  public noConnection: boolean = true;
 
   constructor(private _backendURL: string, private _backendSrv: BackendSrv, public $http) {
     this.isBackendOk();
+    
   }
 
   async postNewItem(
     metric: MetricExpanded, datasourceRequest: DatasourceRequest, 
     newItem: AnalyticUnit, panelId: number
   ): Promise<AnalyticUnitId> {
-    if(this.isUp) {
-      let datasource = await this._backendSrv.get(`/api/datasources/name/${metric.datasource}`);
+      let datasource = await this.get(`/api/datasources/name/${metric.datasource}`);
       datasourceRequest.type = datasource.type;
 
-      return this._backendSrv.post(
-        this._backendURL + '/analyticUnits',
-        {
+      return this.post(this._backendURL + '/analyticUnits', {
           panelUrl: window.location.origin + window.location.pathname + `?panelId=${panelId}&fullscreen`,
           type: newItem.type,
           name: newItem.name,
           metric: metric.toJSON(),
           datasource: datasourceRequest
         }
-      ).then(res => res.id as AnalyticUnitId);
+      )
+        .then(res => res.id as AnalyticUnitId);
     }
-  };
 
   async isBackendOk(): Promise<boolean> {
-    try {
-      let response = await this.$http({ method: 'GET', url: this._backendURL });
+    try { 
+      let response = await this.$http({ method: 'GET', url: this._backendURL }); 
       if(response.status !== -1) {
         this.isUp = true;
         return true;
       } else {
         this.isUp = false;
+        return false;
       }
       // TODO: check version
     } catch(e) {
@@ -56,110 +54,124 @@ export class AnalyticService {
   async updateSegments(
     id: AnalyticUnitId, addedSegments: SegmentsSet<Segment>, removedSegments: SegmentsSet<Segment>
   ): Promise<SegmentId[]> {
-    if (this.isUp) {
-      const getJSONs = (segs: SegmentsSet<Segment>) => segs.getSegments().map(segment => ({
-        from: segment.from,
-        to: segment.to
-      }));
+    const getJSONs = (segs: SegmentsSet<Segment>) => segs.getSegments().map(segment => ({
+      from: segment.from,
+      to: segment.to
+    }));
 
-      var payload = {
-        id,
-        addedSegments: getJSONs(addedSegments),
-        removedSegments: removedSegments.getSegments().map(s => s.id)
-      };
+    var payload = {
+      id,
+      addedSegments: getJSONs(addedSegments),
+      removedSegments: removedSegments.getSegments().map(s => s.id)
+    };
 
-      var data = await this._backendSrv.patch(this._backendURL + '/segments', payload);
-      if (data.addedIds === undefined) {
-        throw new Error('Server didn`t send addedIds');
-      }
-
-      return data.addedIds as SegmentId[];
+    var data = await this.patch(this._backendURL + '/segments', payload);
+    if (data.addedIds === undefined) {
+      throw new Error('Server didn`t send addedIds');
     }
+    return data.addedIds as SegmentId[];
   }
 
   async getSegments(id: AnalyticUnitId, from?: number, to?: number): Promise<AnalyticSegment[]> {
-    if(this.isUp) {
-      if (id === undefined) {
-        throw new Error('id is undefined');
-      }
-      var payload: any = { id };
-      if (from !== undefined) {
-        payload['from'] = from;
-      }
-      if (to !== undefined) {
-        payload['to'] = to;
-      }
-      var data = await this._backendSrv.get(this._backendURL + '/segments', payload);
-      if (data.segments === undefined) {
-        throw new Error('Server didn`t return segments array');
-      }
-      var segments = data.segments as { id: SegmentId, from: number, to: number, labeled: boolean, deleted: boolean }[];
-      return segments.map(s => new AnalyticSegment(s.labeled, s.id, s.from, s.to, s.deleted));
+    if (id === undefined) {
+      throw new Error('id is undefined');
     }
+    var payload: any = { id };
+    if (from !== undefined) {
+      payload['from'] = from;
+    }
+    if (to !== undefined) {
+      payload['to'] = to;
+    }
+    var data = await this.get(this._backendURL + '/segments', payload);
+    if (data.segments === undefined) {
+      throw new Error('Server didn`t return segments array');
+    }
+    var segments = data.segments as { id: SegmentId, from: number, to: number, labeled: boolean, deleted: boolean }[];
+    return segments.map(s => new AnalyticSegment(s.labeled, s.id, s.from, s.to, s.deleted));
   }
 
   async * getStatusGenerator(id: AnalyticUnitId, duration: number) {
-    if(this.isUp) {
-      if (id === undefined) {
-        throw new Error('id is undefined');
-      }
-      let statusCheck = async () => {
-        var data = await this._backendSrv.get(
-          this._backendURL + '/analyticUnits/status', { id }
-        );
-        return data;
-      }
+    if (id === undefined) {
+      throw new Error('id is undefined');
+    }
+    let statusCheck = async () => {
+      var data = await this.get(this._backendURL + '/analyticUnits/status', { id });
+      return data;
+    }
 
-      let timeout = async () => new Promise(
-        resolve => setTimeout(resolve, duration)
-      );
+    let timeout = async () => new Promise(
+      resolve => setTimeout(resolve, duration)
+    );
 
-      while (true) {
-        yield await statusCheck();
-        await timeout();
-      }
+    while (true) {
+      yield await statusCheck();
+      await timeout();
     }
   }
 
   async getAlertEnabled(id: AnalyticUnitId): Promise<boolean> {
-    if(this.isUp) {
-      if (id === undefined) {
-        throw new Error('id is undefined');
-      }
-      var data = await this._backendSrv.get(
-        this._backendURL + '/alerts', { id }
-      );
-      if (data.enabled === undefined) {
-        throw new Error('Server didn`t return "enabled"');
-      }
-      return data.enabled as boolean;
+    if (id === undefined) {
+      throw new Error('id is undefined');
     }
+    var data = await this.get(this._backendURL + '/alerts', { id });
+    if (data.enabled === undefined) {
+      throw new Error('Server didn`t return "enabled"');
+    }
+    return data.enabled as boolean;
   }
 
   async setAlertEnabled(id: AnalyticUnitId, enabled: boolean): Promise<void> {
-    if(this.isUp) {
-      if (id === undefined) {
-        throw new Error('id is undefined');
-      }
-      return this._backendSrv.post(
-        this._backendURL + '/alerts', { id, enabled }
-      );
+    if (id === undefined) {
+      throw new Error('id is undefined');
     }
+    return await this.post(this._backendURL + '/alerts', { id, enabled });
   }
 
   async getServerInfo(): Promise<ServerInfo> {
-    if(this.isUp) {
-      let data = await this._backendSrv.get(this._backendURL);
-      return {
-        nodeVersion: data.nodeVersion,
-        packageVersion: data.packageVersion,
-        npmUserAgent: data.npmUserAgent,
-        docker: data.docker,
-        zmqConectionString: data.zmqConectionString,
-        serverPort: data.serverPort,
-        gitBranch: data.git.branch,
-        gitCommitHash: data.git.commitHash
-      };
+    let data = await this.get(this._backendURL);
+    return {
+      nodeVersion: data.nodeVersion,
+      packageVersion: data.packageVersion,
+      npmUserAgent: data.npmUserAgent,
+      docker: data.docker,
+      zmqConectionString: data.zmqConectionString,
+      serverPort: data.serverPort,
+      gitBranch: data.git.branch,
+      gitCommitHash: data.git.commitHash
+    };
+  }
+
+  private async get(url, params?) {
+    try {
+      let response = await this.$http({ method: 'GET', url: url, params: params });
+      this.isUp = true;
+      return response.data;
+    } catch (error) {
+      console.log(error);
+      this.isUp = false
+    } 
+  }
+
+  private async post(url, data) {
+    try {
+      let response = await this.$http({ method: 'POST', url: url, data: data });
+      this.isUp = true;
+      return response.data;
+    } catch (error) {
+      console.log(error);
+      this.isUp = false;
+    } 
+  }
+
+  private async patch(url, data) {
+    try {
+      let response = await this.$http({ method: 'PATCH', url: url, data: data });
+      this.isUp = true;
+      return response.data;
+    } catch (error) {
+      console.log(error);
+      this.isUp = false;
     }
   }
 }

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -5,13 +5,11 @@ import { SegmentsSet } from '../models/segment_set';
 import { AnalyticUnitId, AnalyticUnit, AnalyticSegment } from '../models/analytic_unit';
 import { ServerInfo } from '../models/info';
 
-import { BackendSrv } from 'grafana/app/core/services/backend_srv';
-
 
 export class AnalyticService {
   private _isUp: boolean = false;
 
-  constructor(private _backendURL: string, private _backendSrv: BackendSrv, public $http, public alertSrv) {
+  constructor(private _backendURL: string, private $http, private alertSrv) {
     this.isBackendOk();
   }
 

--- a/src/services/analytic_service.ts
+++ b/src/services/analytic_service.ts
@@ -11,9 +11,8 @@ import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 export class AnalyticService {
   public isUp: boolean = false;
 
-  constructor(private _backendURL: string, private _backendSrv: BackendSrv, public $http) {
+  constructor(private _backendURL: string, private _backendSrv: BackendSrv, public $http, public alertSrv) {
     this.isBackendOk();
-    
   }
 
   async postNewItem(
@@ -130,6 +129,7 @@ export class AnalyticService {
 
   async getServerInfo(): Promise<ServerInfo> {
     let data = await this.get(this._backendURL);
+    console.log(data)
     return {
       nodeVersion: data.nodeVersion,
       packageVersion: data.packageVersion,
@@ -148,6 +148,11 @@ export class AnalyticService {
       this.isUp = true;
       return response.data;
     } catch (error) {
+      this.alertSrv.set(
+        'lost connection to Hastic server',
+        `Hastic server: "${this._backendURL}"`,
+        'warning', 4000
+      );
       console.log(error);
       this.isUp = false
     } 
@@ -159,6 +164,11 @@ export class AnalyticService {
       this.isUp = true;
       return response.data;
     } catch (error) {
+      this.alertSrv.set(
+        'lost connection to Hastic server',
+        `Hastic server: "${this._backendURL}"`,
+        'warning', 4000
+      );
       console.log(error);
       this.isUp = false;
     } 
@@ -170,6 +180,11 @@ export class AnalyticService {
       this.isUp = true;
       return response.data;
     } catch (error) {
+      this.alertSrv.set(
+        'lost connection to Hastic server',
+        `Hastic server: "${this._backendURL}"`,
+        'warning', 4000
+      );
       console.log(error);
       this.isUp = false;
     }


### PR DESCRIPTION
closes https://github.com/hastic/hastic-grafana-graph-panel/issues/48

1. When dashboard is opened and hastic server is already connected:
![image](https://user-images.githubusercontent.com/22073083/48571211-5dadf000-e917-11e8-804d-3b2a4999a27a.png)

2. When any action with analytic units is performed and server is NOT connected:
![image](https://user-images.githubusercontent.com/22073083/48571703-a1552980-e918-11e8-900f-ee96bebe9eda.png)

3. When dashboard is loaded and hastic server is NOT connected:
![image](https://user-images.githubusercontent.com/22073083/48571666-8aaed280-e918-11e8-8b39-e2eb42d09d42.png)


Panel now checks if the server is up or down, when performing get/post/patch actions.
If any method crashes due to server being down - warning is shown and `reconnect` button appears.