### PR TITLE
rename plugin info tab to Hastic info

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -258,7 +258,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.addEditorTab('Axes', axesEditorComponent, 4);
     this.addEditorTab('Legend', `${partialPath}/tab_legend.html`, 5);
     this.addEditorTab('Display', `${partialPath}/tab_display.html`, 6);
-    this.addEditorTab('Plugin info', `${partialPath}/tab_info.html`, 7);
+    this.addEditorTab('Hastic info', `${partialPath}/tab_info.html`, 7);
 
     this.subTabIndex = 0;
   }


### PR DESCRIPTION
Per request:
![image](https://user-images.githubusercontent.com/22073083/50012211-175bb780-ffcf-11e8-9520-b1d78f6ff657.png)

Tab is renamed:
![image](https://user-images.githubusercontent.com/22073083/50012227-22164c80-ffcf-11e8-851c-22c30dabae97.png)
