### PR TITLE
Table legend is not shown #149

### DIFF
--- a/src/graph_legend.ts
+++ b/src/graph_legend.ts
@@ -139,11 +139,12 @@ export class GraphLegend {
       tableHeaderElem = $(header);
     }
 
-    this.seriesList = _.sortBy(this.seriesList, series => series.stats[this.panel.legend.sort]);
-    
-    if (this.panel.legend.sortDesc) {
-      this.seriesList = this.seriesList.reverse();
+    if (this.panel.legend.sort) {
+      this.seriesList = _.sortBy(this.seriesList, series => series.stats[this.panel.legend.sort]);
+      if (this.panel.legend.sortDesc) {
+        this.seriesList = this.seriesList.reverse();
     }
+  }
 
     // render first time for getting proper legend height
     if (!this.panel.legend.rightSide) {

--- a/src/graph_legend.ts
+++ b/src/graph_legend.ts
@@ -139,13 +139,10 @@ export class GraphLegend {
       tableHeaderElem = $(header);
     }
 
-    if (this.panel.legend.sort) {
-      this.seriesList = _.sortBy(this.seriesList, function(series) {
-        return series.stats[this.panel.legend.sort];
-      });
-      if (this.panel.legend.sortDesc) {
-        this.seriesList = this.seriesList.reverse();
-      }
+    this.seriesList = _.sortBy(this.seriesList, series => series.stats[this.panel.legend.sort]);
+    
+    if (this.panel.legend.sortDesc) {
+      this.seriesList = this.seriesList.reverse();
     }
 
     // render first time for getting proper legend height

--- a/src/graph_renderer.ts
+++ b/src/graph_renderer.ts
@@ -122,7 +122,7 @@ export class GraphRenderer {
         } else {
           this._analyticController.addLabelSegment(segment);
         }
-        this._renderPanel();
+        this.renderPanel();
         return;
       }
 
@@ -202,7 +202,7 @@ export class GraphRenderer {
     // this.annotations = this.ctrl.annotations || [];
     this._buildFlotPairs(this.data);
     updateLegendValues(this.data, this.panel);
-    this._renderPanel();
+    this.renderPanel();
     if(this.tooltip.visible) {
       var pos = this.plot.c2p(this._graphMousePosition);
       var canvasOffset = this.$elem.find('.flot-overlay').offset();
@@ -314,7 +314,7 @@ export class GraphRenderer {
   }
 
   // Function for rendering panel
-  private _renderPanel() {
+  public renderPanel() {
 
     this.panelWidth = this.$elem.width();
     if (this._shouldAbortRender()) {

--- a/src/graph_renderer.ts
+++ b/src/graph_renderer.ts
@@ -122,7 +122,6 @@ export class GraphRenderer {
         } else {
           this._analyticController.addLabelSegment(segment);
         }
-        this.renderPanel();
         return;
       }
 
@@ -202,7 +201,6 @@ export class GraphRenderer {
     // this.annotations = this.ctrl.annotations || [];
     this._buildFlotPairs(this.data);
     updateLegendValues(this.data, this.panel);
-    this.renderPanel();
     if(this.tooltip.visible) {
       var pos = this.plot.c2p(this._graphMousePosition);
       var canvasOffset = this.$elem.find('.flot-overlay').offset();

--- a/src/module.ts
+++ b/src/module.ts
@@ -386,12 +386,10 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     if(!this.analyticsController.graphLocked) {
-      this._graphLegend.render();
       this._graphRenderer.render(data);
+      this._graphLegend.render();
+      this._graphRenderer.renderPanel();
     }
-
-    this._graphLegend.render();
-    this._graphRenderer.renderPanel();
   }
 
   changeSeriesColor(series, color) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -389,6 +389,9 @@ class GraphCtrl extends MetricsPanelCtrl {
       this._graphLegend.render();
       this._graphRenderer.render(data);
     }
+
+    this._graphLegend.render();
+    this._graphRenderer.renderPanel();
   }
 
   changeSeriesColor(series, color) {


### PR DESCRIPTION
closes https://github.com/hastic/hastic-grafana-app/issues/149

Table legend is now shown after page reload.
No previous errors in console:
![image](https://user-images.githubusercontent.com/22073083/51992202-a2c8d380-24bd-11e9-9f64-55e6263bbc26.png)

p.s. used same fix from <a href="https://github.com/CorpGlory/grafana-multibar-graph-panel/commit/3856d3385d5c466227b6041195d28ece492de296#diff-71140e89e90b8de9f9404d7dc33776aa">here</a>