### PR TITLE
Hastic server at "" is not available #166

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -189,6 +189,7 @@ class GraphCtrl extends MetricsPanelCtrl {
   async updateAnalyticUnitTypes() {
     const analyticUnitTypes = await this.analyticService.getAnalyticUnitTypes();
     this._analyticUnitTypes = analyticUnitTypes;
+    this.$scope.$digest();
   }
 
   get analyticUnitTypes() {


### PR DESCRIPTION
fixes #166 
I added one more `$digest()` it's a hack a bit cuz I call `$digest()` when I get `hasticServerUrl`
I can guarantee that it will be called after I get `hasticServerUrl`