### PR TITLE
Deleted color css #192

### DIFF
--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -47,6 +47,9 @@
         />
       </span>
 
+      <!-- This dev breaks Grafana's gf-form + gf-form css. It is a fix for https://github.com/hastic/hastic-grafana-app/issues/192 -->
+      <div></div>
+
       <label class="gf-form-label width-8"> Deleted Color </label>
       <span class="gf-form-label">
         <color-picker

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -47,7 +47,7 @@
         />
       </span>
 
-      <!-- This dev breaks Grafana's gf-form + gf-form css. It is a fix for https://github.com/hastic/hastic-grafana-app/issues/192 -->
+      <!-- Hack to avoid Grafana's .gf-form-label + .gf-form-label css. Fix for https://github.com/hastic/hastic-grafana-app/issues/192 -->
       <div></div>
 
       <label class="gf-form-label width-8"> Deleted Color </label>


### PR DESCRIPTION
closes https://github.com/hastic/hastic-grafana-app/issues/192

The tab now looks like this:
![image](https://user-images.githubusercontent.com/22073083/53404920-b9345300-39c7-11e9-942b-2bdac1a92838.png)
