### PR TITLE
Missing statuses and updates on saving #230

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -273,12 +273,15 @@ export class AnalyticController {
     return newIds;
   }
 
-  redetectAll() {
-    this.analyticUnits.forEach(a => {
-      a.segments.clear();
-      this._runStatusWaiter(a);
-      this._analyticService.runDetect(a.id);
+  async redetectAll() {
+    this.analyticUnits.forEach(unit => {
+      unit.segments.clear();
+      unit.status = undefined;
     });
+    const ids = this.analyticUnits.map(analyticUnit => analyticUnit.id);
+    await this._analyticService.runDetect(ids);
+
+    _.each(this.analyticUnits, analyticUnit => this._runStatusWaiter(analyticUnit));
   }
 
   // TODO: move to renderer

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -276,7 +276,7 @@ export class AnalyticController {
   async redetectAll() {
     this.analyticUnits.forEach(unit => {
       unit.segments.clear();
-      unit.status = undefined;
+      unit.status = null;
     });
     const ids = this.analyticUnits.map(analyticUnit => analyticUnit.id);
     await this._analyticService.runDetect(ids);

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -115,9 +115,6 @@ export class AnalyticController {
     this._analyticUnitsSet.addItem(this._newAnalyticUnit);
     this._creatingNewAnalyticType = false;
     this._savingNewAnalyticUnit = false;
-    if(this._newAnalyticUnit.detectorType !== 'threshold') {
-      this._runStatusWaiter(this._newAnalyticUnit);
-    }
   }
 
   get creatingNew() { return this._creatingNewAnalyticType; }
@@ -134,7 +131,7 @@ export class AnalyticController {
     return this._analyticUnitsSet.byId(this._selectedAnalyticUnitId);
   }
 
-  async toggleUnitTypeLabelingMode(id: AnalyticUnitId, metric: MetricExpanded, datasource: DatasourceRequest) {
+  async toggleAnalyticUnitLabelingMode(id: AnalyticUnitId, metric: MetricExpanded, datasource: DatasourceRequest) {
     this._currentMetric = metric;
     this._currentDatasource = datasource;
 
@@ -148,7 +145,6 @@ export class AnalyticController {
     this._selectedAnalyticUnitId = id;
     this.labelingUnit.selected = true;
     this.toggleLabelingMode(LabelingMode.LABELING);
-    this.toggleVisibility(id, true);
   }
 
   async disableLabeling() {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -158,6 +158,9 @@ class GraphCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel.legend, this.panelDefaults.legend);
     _.defaults(this.panel.xaxis, this.panelDefaults.xaxis);
 
+    // because of https://github.com/hastic/hastic-grafana-app/issues/162
+    this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
+
     const grafanaUrlRegex = /^(.+)\/d/;
     const parsedUrl = window.location.href.match(grafanaUrlRegex);
     if(parsedUrl !== null) {
@@ -255,7 +258,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.events.on('data-error', this.onDataError.bind(this));
     this.events.on('data-snapshot-load', this.onDataSnapshotLoad.bind(this));
     this.events.on('init-panel-actions', this.onInitPanelActions.bind(this));
-    this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
 
     this.events.on('analytic-unit-status-change', async (analyticUnit: AnalyticUnit) => {
       if(analyticUnit === undefined) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -315,7 +315,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.processor = new DataProcessor(this.panel);
 
     await this._fetchHasticDatasources();
-    let hasticDatasource = this.getHasticDatasource();
+    const hasticDatasource = this.getHasticDatasource();
     if(hasticDatasource === undefined) {
       delete this.analyticService;
     } else {
@@ -682,7 +682,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       grafanaUrl: window.location.host,
       datasourceName: datasource === undefined ? 'unknown' : datasource.name,
       datasourceType: datasource === undefined ? 'unknown' : datasource.type,
-      hasticDatasourceName: datasource === undefined ? 'unknown' : hasticDatasource.name,
+      hasticDatasourceName: hasticDatasource === undefined || datasource === undefined ? 'unknown' : hasticDatasource.name,
       hasticDatasourceUrl: hasticDatasource === undefined ? 'unknown' : hasticDatasource.url
     };
   }

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -253,6 +253,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.$graphElem = $(elem[0]).find('#graphPanel');
     this.$legendElem = $(elem[0]).find('#graphLegend');
 
+    this.onHasticDatasourceChange();
+
     this.events.on('render', this.onRender.bind(this));
     this.events.on('data-received', this.onDataReceived.bind(this));
     this.events.on('data-error', this.onDataError.bind(this));
@@ -287,8 +289,6 @@ class GraphCtrl extends MetricsPanelCtrl {
         type: undefined
       };
     });
-
-    await this.onHasticDatasourceChange();
   }
 
   onInitEditMode() {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -638,7 +638,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
     const datasource = await this._getDatasourceRequest();
     const metric = new MetricExpanded(this.panel.datasource, this.panel.targets);
-    await this.analyticsController.toggleUnitTypeLabelingMode(id, metric, datasource);
+    await this.analyticsController.toggleAnalyticUnitLabelingMode(id, metric, datasource);
     this.$scope.$digest();
     this.render();
   }

--- a/src/panel/graph_panel/models/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_unit.ts
@@ -121,7 +121,7 @@ export class AnalyticUnit {
       value !== 'LEARNING' &&
       value !== 'PENDING' &&
       value !== 'FAILED' &&
-      value !== undefined
+      value !== null
     ) {
       throw new Error('Unsupported status value: ' + value);
     }

--- a/src/panel/graph_panel/models/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_unit.ts
@@ -120,7 +120,8 @@ export class AnalyticUnit {
       value !== 'READY' &&
       value !== 'LEARNING' &&
       value !== 'PENDING' &&
-      value !== 'FAILED'
+      value !== 'FAILED' &&
+      value !== undefined
     ) {
       throw new Error('Unsupported status value: ' + value);
     }

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -159,6 +159,7 @@
         </label>
 
         <label>
+          <i ng-if="analyticUnit.status === 'READY'" class="grafana-tip fa fa-check-circle ng-scope" bs-tooltip="'Ready'"></i>
           <i ng-if="analyticUnit.status === 'LEARNING'" class="grafana-tip fa fa-leanpub ng-scope" bs-tooltip="'Learning'"></i>
           <i ng-if="analyticUnit.status === 'PENDING'" class="grafana-tip fa fa-list-ul ng-scope" bs-tooltip="'Pending'"></i>
           <i ng-if="analyticUnit.status === 'FAILED'" class="grafana-tip fa fa-exclamation-circle ng-scope" bs-tooltip="'Error: ' + analyticUnit.error"></i>

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -10,6 +10,7 @@ import { isHasticServerResponse, isSupportedServerVersion, SUPPORTED_SERVER_VERS
 
 import { appEvents } from 'grafana/app/core/core';
 
+import * as _ from 'lodash';
 
 
 export class AnalyticService {
@@ -202,8 +203,11 @@ export class AnalyticService {
     return this.patch('/analyticUnits', updateObj);
   }
 
-  async runDetect(id: AnalyticUnitId) {
-    return this.post('/analyticUnits/detect', { id });
+  async runDetect(ids: AnalyticUnitId | AnalyticUnitId[]) {
+    if(!_.isArray(ids)) {
+      ids = [ids];
+    }
+    return this.post('/analyticUnits/detect', { ids });
   }
 
   private async _analyticRequest(method: string, url: string, data?: any) {

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -96,8 +96,7 @@ export class AnalyticService {
     if(!isHasticServerResponse(response)) {
       this.displayWrongUrlAlert();
       this._isUp = false;
-    }
-    if(!isSupportedServerVersion(response)) {
+    } else if(!isSupportedServerVersion(response)) {
       this.displayUnsupportedVersionAlert(response.packageVersion);
       this._isUp = false;
     }


### PR DESCRIPTION
Fixes #230 

There were a few problems:
- analytic unit status was not reset when re-detecting (thus, it was left in READY state)
- detections was sent to server one-by-one (instead of batch)

Changes:
- Add READY status icon
![image](https://user-images.githubusercontent.com/1989898/55420251-3894e380-557f-11e9-90de-114d74ecfc75.png)
- Send batch detect request (hastic/hastic-server#500)
- Make Hastic Graph work when there is no hastic-datasource (or it doesn't work)