### PR TITLE
Hastic server at "" is not available #166

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -197,7 +197,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.rebindKeys();
   }
 
-  getHasticDatasource(): { url: string, name: string } | undefined {
+  get hasticDatasource(): { url: string, name: string } | undefined {
     const hasticDatasourceId = this.panel.hasticDatasource;
     if(hasticDatasourceId !== undefined && hasticDatasourceId !== null) {
       const hasticDatasource = _.find(this._hasticDatasources, { id: hasticDatasourceId });
@@ -314,7 +314,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.processor = new DataProcessor(this.panel);
 
     await this._fetchHasticDatasources();
-    let hasticDatasource = this.getHasticDatasource();
+    let hasticDatasource = this.hasticDatasource;
     if(hasticDatasource === undefined) {
       delete this.analyticService;
     } else {
@@ -670,7 +670,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       datasource = await this._getDatasourceByName(this.panel.datasource);
     }
 
-    const hasticDatasource = this.getHasticDatasource();
+    const hasticDatasource = this.hasticDatasource;
 
     let grafanaVersion = 'unknown';
     if(_.has(window, 'grafanaBootData.settings.buildInfo.version')) {

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -11,7 +11,7 @@
 
 <div class="gf-form">
   <div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
-    <h5>Hastic server at "{{ctrl.backendURL}}" is not available</h5>
+    <h5>Hastic server at "{{ctrl.hasticDatasource.url}}" is not available</h5>
     <button class="btn btn-inverse" ng-click="ctrl.runDatasourceConnectivityCheck()">
       <i class="fa fa-plug"></i>
       Reconnect to Hastic server

--- a/src/panel/graph_panel/partials/tab_webhooks.html
+++ b/src/panel/graph_panel/partials/tab_webhooks.html
@@ -1,5 +1,5 @@
 <div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
-  <h5>Hastic server at "{{ctrl.backendURL}}" is not available</h5>
+  <h5>Hastic server at "{{ctrl.hasticDatasource.url}}" is not available</h5>
   <button class="btn btn-inverse" ng-click="ctrl.runBackendConnectivityCheck()">
     <i class="fa fa-plug"></i>
     Reconnect to Hastic server


### PR DESCRIPTION
Fixes #166 

![image](https://user-images.githubusercontent.com/1989898/55575857-8f81f080-5718-11e9-92c7-8b2a317981e6.png)

The reason was old `backendUrl` field usage

Changes:
- `getHasticDatasource()` -> `get hasticDatasource()`
- `backendUrl` -> `hasticDatasource.url`