### PR TITLE
Analytic units' fields are not saved to db #240

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -106,7 +106,7 @@ export class AnalyticController {
 
   async saveNew(metric: MetricExpanded, datasource: DatasourceRequest) {
     this._savingNewAnalyticUnit = true;
-    this._newAnalyticUnit.id = await this._analyticService.postNewItem(
+    this._newAnalyticUnit.id = await this._analyticService.postNewAnalyticUnit(
       this._newAnalyticUnit, metric, datasource, this._grafanaUrl, this._panelId
     );
     if(this._newAnalyticUnit.detectorType === 'threshold') {

--- a/src/panel/graph_panel/models/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_unit.ts
@@ -52,7 +52,7 @@ export class AnalyticUnit {
       alert: false,
       id: null,
       visible: true
-    }
+    };
 
     if(_serverObject === undefined) {
       this._serverObject = defaults;

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -53,8 +53,8 @@ export class AnalyticService {
     return this.patch('/threshold', threshold);
   }
 
-  async postNewItem(
-    newItem: AnalyticUnit,
+  async postNewAnalyticUnit(
+    analyticUnit: AnalyticUnit,
     metric: MetricExpanded,
     datasource: DatasourceRequest,
     grafanaUrl: string,
@@ -63,8 +63,14 @@ export class AnalyticService {
     const response = await this.post('/analyticUnits', {
       grafanaUrl,
       panelId,
-      type: newItem.type,
-      name: newItem.name,
+      // TODO: serialize analytic unit
+      name: analyticUnit.name,
+      type: analyticUnit.type,
+      alert: analyticUnit.alert,
+      labeledColor: analyticUnit.labeledColor,
+      deletedColor: analyticUnit.deletedColor,
+      detectorType: analyticUnit.detectorType,
+      visible: analyticUnit.visible,
       metric: metric.toJSON(),
       datasource
     });

--- a/tests/setup_tests.ts
+++ b/tests/setup_tests.ts
@@ -17,7 +17,7 @@ function $http() {
 } 
 
 const analyticService = new AnalyticService('', $http);
-analyticService.postNewItem = async function (
+analyticService.postNewAnalyticUnit = async function (
   newItem: AnalyticUnit, metric: MetricExpanded, 
   datasource: DatasourceRequest, panelUrl: string
 ): Promise<AnalyticUnitId> {


### PR DESCRIPTION
Fixes #240 
Fixes #232 
Fixes #233

Changes:
- Send all analytic unit's fields to server on creation