### PR TITLE
Can't use default datasource #253

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -696,15 +696,19 @@ class GraphCtrl extends MetricsPanelCtrl {
   }
 
   private async _getDatasourceByName(name: string) {
-    if(name === null) {
-      throw new Error('Trying to get datasource with NULL name');
-    }
     if(this._datasources[name] === undefined) {
-      const datasource = await this.backendSrv.get(`api/datasources/name/${name}`);
-      return datasource;
-    } else {
-      return this._datasources[name];
+      if(name === null) {
+        // Default datasource has null name
+        const datasources = await this.backendSrv.get(`api/datasources`);
+        this._datasources[name] = _.find(datasources, datasource => datasource.isDefault);
+        if(this._datasources[name] === undefined) {
+          throw new Error('No default datasource found');
+        }
+      } else {
+        this._datasources[name] = await this.backendSrv.get(`api/datasources/name/${name}`);
+      }
     }
+    return this._datasources[name];
   }
 
   private async _fetchHasticDatasources() {


### PR DESCRIPTION
Fixes #253 

Default datasource has `null` name
Thus, it can't be queried from Grafana API by name
The solution is to find datasource with `isDefault: true` in datasources list

Also, PR fixes not working cache of `_getDatasourceByName` method