### PR TITLE
Confusing save/label/apply/detect buttons #280

### DIFF
--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -156,7 +156,7 @@
 
         <label
           class="gf-form-label"
-          ng-if="analyticUnit.detectorType === 'pattern'"
+          ng-if="analyticUnit.detectorType === 'pattern' && analyticUnit.selected"
           ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
         >
           <a class="pointer" tabindex="1"
@@ -165,7 +165,6 @@
           >
             <i class="fa fa-bar-chart" ng-if="!analyticUnit.saving"></i>
             <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
-            <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
           </a>
         </label>
 
@@ -179,6 +178,22 @@
           ng-if="analyticUnit.selected && !analyticUnit.saving"
           ng-disabled="analyticUnit.status === 'LEARNING'"
         />
+
+        <label
+          class="gf-form-label"
+          ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
+          ng-if="analyticUnit.selected && !analyticUnit.saving"
+          ng-disabled="analyticUnit.status === 'LEARNING'"
+        >
+          <a class="pointer"
+            ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
+            ng-disabled="analyticUnit.status === 'LEARNING'"
+          >
+            <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
+            <b ng-if="!analyticUnit.saving"> Detect </b>
+            <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
+            </a>
+        </label>
 
         <label class="gf-form-label">
           <a

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -180,6 +180,7 @@
           ng-disabled="analyticUnit.status === 'LEARNING'"
         />
 
+        <!-- Standard way to add conditions to ng-style: https://stackoverflow.com/a/29470439 -->
         <label
           class="gf-form-label"
           ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -156,7 +156,7 @@
 
         <label
           class="gf-form-label"
-          ng-if="analyticUnit.detectorType === 'pattern' && analyticUnit.selected"
+          ng-if="analyticUnit.detectorType === 'pattern' && !analyticUnit.selected"
           ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
         >
           <a class="pointer" tabindex="1"
@@ -166,6 +166,7 @@
             <i class="fa fa-bar-chart" ng-if="!analyticUnit.saving"></i>
             <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
           </a>
+          Label
         </label>
 
         <select class="gf-form-input width-12"


### PR DESCRIPTION
Closes #280 
Closes #218 

Analytic units with different detector types have a common `Detect` button now

Changed only analytic unit with "Pattern" detector type:
- `Detect` button in labeling mode:
![image](https://user-images.githubusercontent.com/39257464/57395048-bf1c9080-71cf-11e9-9c38-d391be03254f.png)

- `Label` sign beside labeling button (to show button purpose explicitly):
![image](https://user-images.githubusercontent.com/39257464/57395113-eecb9880-71cf-11e9-91ea-6c5b8c470eb8.png)

This is how other detectors look:
![image](https://user-images.githubusercontent.com/39257464/57396577-546d5400-71d3-11e9-8d54-9b54a65599a8.png)
