### PR TITLE
Color picker is broken #275

### DIFF
--- a/src/panel/graph_panel/graph_legend.ts
+++ b/src/panel/graph_panel/graph_legend.ts
@@ -46,7 +46,7 @@ export class GraphLegend {
       position: 'bottom left',
       targetAttachment: 'top left',
       template:
-        '<series-color-picker series="series" onToggleAxis="toggleAxis" onColorChange="colorSelected"/>',
+        '<series-color-picker-popover series="series" onToggleAxis="toggleAxis" onColorChange="colorSelected"/>',
       openOn: 'hover',
       model: {
         series: series,

--- a/src/panel/graph_panel/series_overrides_ctrl.ts
+++ b/src/panel/graph_panel/series_overrides_ctrl.ts
@@ -54,7 +54,7 @@ export class SeriesOverridesCtrl {
         element: $element.find('.dropdown')[0],
         position: 'top center',
         openOn: 'click',
-        template: '<series-color-picker series="series" onColorChange="colorSelected" />',
+        template: '<series-color-picker-popover series="series" onColorChange="colorSelected" />',
         model: {
           autoClose: true,
           colorSelected: $scope.colorSelected,


### PR DESCRIPTION
Closes #275 

`seriesColorPicker` Angular component was rewritten to React and renamed to `seriesColorPickerPopover` in this PR: https://github.com/grafana/grafana/pull/13740
This change was released in 5.3.3 Grafana version, as far as I understand

Changes:
`series-color-picker` -> `series-color-picker-popover`

![image](https://user-images.githubusercontent.com/1989898/57450482-3c471480-7267-11e9-83e8-0405f25b427e.png)

P.S. this rename fully suits `hastic-grafana-app` because we don't support Grafana < 5.4.0