### PR TITLE
HSR in Inspect mode #279

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -688,14 +688,6 @@ export class AnalyticController {
     }
   }
 
-  public toggleHSR(id: AnalyticUnitId) {
-    // TODO: remove toggleInspect duplication
-    const analyticUnit = this._analyticUnitsSet.byId(id);
-    if(!analyticUnit.showHSR) {
-      this.analyticUnits.forEach(unit => unit.showHSR = false);
-    }
-  }
-
   public onAnalyticUnitDetectorChange(analyticUnitTypes: any) {
     // TODO: looks bad
     this._newAnalyticUnit.type = analyticUnitTypes[this._newAnalyticUnit.detectorType][0].value;

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -672,10 +672,9 @@ export class AnalyticController {
   }
 
   public toggleInspect(id: AnalyticUnitId) {
-    const analyticUnit = this._analyticUnitsSet.byId(id);
-    if(!analyticUnit.inspect) {
-      this.analyticUnits.forEach(unit => unit.inspect = false);
-    }
+    this.analyticUnits
+      .filter(analyticUnit => analyticUnit.id !== id)
+      .forEach(unit => unit.inspect = false);
   }
 
   public onAnalyticUnitDetectorChange(analyticUnitTypes: any) {

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -504,13 +504,13 @@ export class AnalyticController {
   }
 
   async getHSR(from: number, to: number): Promise<HSRTimeSeries | null> {
-    // Returns HSR (Hastic Signal Representation) for analytic unit with enabled "Show HSR"
-    // Returns null when there is no analytic units which have "Show HSR" enabled
-    if(this.hsrAnalyticUnit === null) {
+    // Returns HSR (Hastic Signal Representation) for analytic unit in "Inspect" mode
+    // Returns null when there is no analytic units in "Inspect" mode
+    if(this.inspectedAnalyticUnit === null) {
       return null;
     }
 
-    const hsr = await this._analyticService.getHSR(this.hsrAnalyticUnit.id, from, to);
+    const hsr = await this._analyticService.getHSR(this.inspectedAnalyticUnit.id, from, to);
     const datapoints = hsr.values.map(value => value.reverse() as [number, number]);
     return { target: 'HSR', datapoints };
   }
@@ -521,8 +521,8 @@ export class AnalyticController {
     if(hsr === null) {
       return [];
     }
-    if(this.hsrAnalyticUnit.detectorType === DetectorType.ANOMALY) {
-      const confidence = (this.hsrAnalyticUnit as AnomalyAnalyticUnit).confidence;
+    if(this.inspectedAnalyticUnit.detectorType === DetectorType.ANOMALY) {
+      const confidence = (this.inspectedAnalyticUnit as AnomalyAnalyticUnit).confidence;
       // TODO: looks bad
       return [
         {
@@ -556,16 +556,6 @@ export class AnalyticController {
   get inspectedAnalyticUnit(): AnalyticUnit | null {
     for(let analyticUnit of this.analyticUnits) {
       if(analyticUnit.inspect) {
-        return analyticUnit;
-      }
-    };
-    return null;
-  }
-
-  get hsrAnalyticUnit(): AnalyticUnit | null {
-    // TODO: remove inspectedAnalyticUnit duplication
-    for(let analyticUnit of this.analyticUnits) {
-      if(analyticUnit.showHSR) {
         return analyticUnit;
       }
     };

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -683,11 +683,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
   }
 
-  onToggleHSR(id: AnalyticUnitId) {
-    this.analyticsController.toggleHSR(id);
-    this.refresh();
-  }
-
   private async _updatePanelInfo() {
     let datasource = undefined;
     if(this.panel.datasource) {

--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -55,7 +55,6 @@ export class AnalyticUnit {
   private _segmentSet = new SegmentArray<AnalyticSegment>();
   private _detectionSpans: DetectionSpan[];
   private _inspect = false;
-  private _showHSR = false;
   private _status: string;
   private _error: string;
 
@@ -115,9 +114,6 @@ export class AnalyticUnit {
 
   get inspect(): boolean { return this._inspect; }
   set inspect(value: boolean) { this._inspect = value; }
-
-  get showHSR(): boolean { return this._showHSR; }
-  set showHSR(value: boolean) { this._showHSR = value; }
 
   get visible(): boolean {
     return (this._serverObject.visible === undefined) ? true : this._serverObject.visible

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -106,11 +106,12 @@
           ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
         />
 
-        <label class="gf-form-label" ng-if="analyticUnit.visible">
-          Inspect
-        </label>
-
+        <!-- TODO: Remove hack with "margin-bottom: 0" -->
         <gf-form-switch ng-if="analyticUnit.visible"
+          class="gf-form"
+          style="margin-bottom: 0"
+          label="Inspect"
+          label-class="width-5"
           on-change="ctrl.onToggleInspect(analyticUnit.id)"
           checked="analyticUnit.inspect"
         />

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -106,22 +106,13 @@
           ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
         />
 
-        <label class="gf-form-label" ng-if="analyticUnit.status === 'READY' && analyticUnit.visible">
+        <label class="gf-form-label" ng-if="analyticUnit.visible">
           Inspect
         </label>
 
-        <gf-form-switch ng-if="analyticUnit.status === 'READY' && analyticUnit.visible"
+        <gf-form-switch ng-if="analyticUnit.visible"
           on-change="ctrl.onToggleInspect(analyticUnit.id)"
           checked="analyticUnit.inspect"
-        />
-
-        <label class="gf-form-label" ng-if="analyticUnit.visible">
-          HSR
-        </label>
-
-        <gf-form-switch ng-if="analyticUnit.visible"
-          on-change="ctrl.onToggleHSR(analyticUnit.id)"
-          checked="analyticUnit.showHSR"
         />
 
         <label class="gf-form-label" ng-hide="analyticUnit.selected">


### PR DESCRIPTION
Closes #279 

Now HSR is shown always in `Inspect` mode
It can be hidden by clicking on "HSR" in legend

![image](https://user-images.githubusercontent.com/1989898/57468911-18e39000-728e-11e9-86df-6d1f139e1b41.png)
![image](https://user-images.githubusercontent.com/1989898/57468942-2bf66000-728e-11e9-9183-a6e0d1ad8bd6.png)
![image](https://user-images.githubusercontent.com/1989898/57468978-3add1280-728e-11e9-8d48-0c0090de6a38.png)

Changes:
- show HSR in inspect mode
- remove HSR checkbox
- fix `Inspect` mode checkbox (only 1 analytic at a time can be in inspect mode)