### PR TITLE
Labeling for anomalies #281

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -454,11 +454,7 @@ export class AnalyticController {
     if(!this.inLabelingMode) {
       throw new Error(`Can't enter ${labelingMode} mode when labeling mode is disabled`);
     }
-    if(this.labelingUnit.labelingMode === labelingMode) {
-      this.labelingUnit.labelingMode = LabelingMode.LABELING;
-    } else {
-      this.labelingUnit.labelingMode = labelingMode;
-    }
+    this.labelingUnit.labelingMode = labelingMode;
   }
 
   async removeAnalyticUnit(id: AnalyticUnitId, silent: boolean = false): Promise<void> {

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -198,8 +198,8 @@ export class AnalyticController {
   }
 
   addSegment(segment: Segment, deleted = false) {
-    const asegment = this.labelingUnit.addSegment(segment, deleted);
-    this._labelingDataAddedSegments.addSegment(asegment);
+    const addedSegment = this.labelingUnit.addSegment(segment, deleted);
+    this._labelingDataAddedSegments.addSegment(addedSegment);
   }
 
   get analyticUnits(): AnalyticUnit[] {

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -106,7 +106,7 @@ export class AnalyticController {
 
   async saveNew(metric: MetricExpanded, datasource: DatasourceRequest) {
     this._savingNewAnalyticUnit = true;
-    const newAnalyticUnit = createAnalyticUnit(this._newAnalyticUnit.serverObject);
+    const newAnalyticUnit = createAnalyticUnit(this._newAnalyticUnit.toJSON());
     newAnalyticUnit.id = await this._analyticService.postNewAnalyticUnit(
       newAnalyticUnit, metric, datasource, this._grafanaUrl, this._panelId
     );
@@ -485,7 +485,7 @@ export class AnalyticController {
     }
 
     analyticUnit.saving = true;
-    await this._analyticService.updateAnalyticUnit(analyticUnit.serverObject);
+    await this._analyticService.updateAnalyticUnit(analyticUnit.toJSON());
     analyticUnit.saving = false;
   }
 
@@ -684,7 +684,6 @@ export class AnalyticController {
 
   public async updateSeasonality(id: AnalyticUnitId) {
     const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
-    analyticUnit.updateSeasonality();
     await this.saveAnalyticUnit(analyticUnit);
   }
 

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -196,8 +196,8 @@ export class AnalyticController {
     this.labelingUnit.labelingMode = labelingMode;
   }
 
-  addLabelSegment(segment: Segment, deleted = false) {
-    const asegment = this.labelingUnit.addLabeledSegment(segment, deleted);
+  addSegment(segment: Segment, deleted = false) {
+    const asegment = this.labelingUnit.addSegment(segment, deleted);
     this._labelingDataAddedSegments.addSegment(asegment);
   }
 

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -683,7 +683,7 @@ export class AnalyticController {
 
   public toggleSeasonality(id: AnalyticUnitId) {
     const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
-    analyticUnit.seasonality = 1;
+    analyticUnit.seasonality = 1000;
   }
 
   public async updateSeasonality(id: AnalyticUnitId) {

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -681,6 +681,17 @@ export class AnalyticController {
       .forEach(unit => unit.inspect = false);
   }
 
+  public toggleSeasonality(id: AnalyticUnitId) {
+    const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
+    analyticUnit.seasonality = 1;
+  }
+
+  public async updateSeasonality(id: AnalyticUnitId) {
+    const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
+    analyticUnit.updateSeasonality();
+    await this.saveAnalyticUnit(analyticUnit);
+  }
+
   public onAnalyticUnitDetectorChange(analyticUnitTypes: any) {
     // TODO: looks bad
     this._newAnalyticUnit.type = analyticUnitTypes[this._newAnalyticUnit.detectorType][0].value;

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -681,11 +681,6 @@ export class AnalyticController {
       .forEach(unit => unit.inspect = false);
   }
 
-  public toggleSeasonality(id: AnalyticUnitId) {
-    const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
-    analyticUnit.seasonality = 1000;
-  }
-
   public async updateSeasonality(id: AnalyticUnitId) {
     const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
     analyticUnit.updateSeasonality();

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -143,8 +143,8 @@ export class AnalyticController {
     await this.disableLabeling();
     this._selectedAnalyticUnitId = id;
     this.labelingUnit.selected = true;
-    const modes = this.labelingUnit.labelingModes;
-    this.toggleLabelingMode(modes[0].value);
+    const labelingModes = this.labelingUnit.labelingModes;
+    this.toggleLabelingMode(labelingModes[0].value);
   }
 
   async disableLabeling() {

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -143,7 +143,8 @@ export class AnalyticController {
     await this.disableLabeling();
     this._selectedAnalyticUnitId = id;
     this.labelingUnit.selected = true;
-    this.toggleLabelingMode(LabelingMode.LABELING);
+    const modes = this.labelingUnit.labelingModes;
+    this.toggleLabelingMode(modes[0].value);
   }
 
   async disableLabeling() {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -682,6 +682,11 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
   }
 
+  onSeasonalityChange(id: AnalyticUnitId) {
+    this.analyticsController.updateSeasonality(id);
+    this.refresh();
+  }
+
   private async _updatePanelInfo() {
     let datasource = undefined;
     if(this.panel.datasource) {

--- a/src/panel/graph_panel/graph_renderer.ts
+++ b/src/panel/graph_panel/graph_renderer.ts
@@ -153,10 +153,10 @@ export class GraphRenderer {
         this._analyticController.deleteLabelingAnalyticUnitSegmentsInRange(
           segment.from, segment.to
         );
-        this._analyticController.addLabelSegment(segment, true);
+        this._analyticController.addSegment(segment, true);
       }
       if(this._analyticController.labelingMode === LabelingMode.LABELING) {
-        this._analyticController.addLabelSegment(segment, false);
+        this._analyticController.addSegment(segment, false);
       }
       if(this._analyticController.labelingMode === LabelingMode.UNLABELING) {
         this._analyticController.deleteLabelingAnalyticUnitSegmentsInRange(

--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -50,6 +50,8 @@ const DEFAULTS = {
   visible: true
 };
 
+const LABELING_MODES = [];
+
 export class AnalyticUnit {
 
   private _labelingMode: LabelingMode = LabelingMode.LABELING;
@@ -60,7 +62,6 @@ export class AnalyticUnit {
   private _inspect = false;
   private _status: string;
   private _error: string;
-  protected LABELING_MODES = [];
 
   // TODO: serverObject -> fields
   constructor(protected _serverObject?: any) {
@@ -176,7 +177,8 @@ export class AnalyticUnit {
 
   get serverObject() { return this._serverObject; }
 
+  // TODO: make it abstract
   get labelingModes() {
-    return this.LABELING_MODES;
+    return LABELING_MODES;
   }
 }

--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -122,7 +122,7 @@ export class AnalyticUnit {
     this._serverObject.visible = value;
   }
 
-  addLabeledSegment(segment: Segment, deleted: boolean): AnalyticSegment {
+  addSegment(segment: Segment, deleted: boolean): AnalyticSegment {
     const asegment = new AnalyticSegment(!deleted, segment.id, segment.from, segment.to, deleted);
     this._segmentSet.addSegment(asegment);
     return asegment;

--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -127,9 +127,9 @@ export class AnalyticUnit {
   }
 
   addSegment(segment: Segment, deleted: boolean): AnalyticSegment {
-    const asegment = new AnalyticSegment(!deleted, segment.id, segment.from, segment.to, deleted);
-    this._segmentSet.addSegment(asegment);
-    return asegment;
+    const addedSegment = new AnalyticSegment(!deleted, segment.id, segment.from, segment.to, deleted);
+    this._segmentSet.addSegment(addedSegment);
+    return addedSegment;
   }
 
   removeSegmentsInRange(from: number, to: number): AnalyticSegment[] {

--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -33,6 +33,9 @@ export class AnalyticSegment extends Segment {
     if(!_.isBoolean(this.labeled)) {
       throw new Error('labeled value is not boolean');
     }
+    if(labeled && deleted) {
+      throw new Error('Segment can`t be both labeled and deleted');
+    }
   }
 }
 

--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -60,6 +60,7 @@ export class AnalyticUnit {
   private _inspect = false;
   private _status: string;
   private _error: string;
+  protected LABELING_MODES = [];
 
   // TODO: serverObject -> fields
   constructor(protected _serverObject?: any) {
@@ -175,4 +176,7 @@ export class AnalyticUnit {
 
   get serverObject() { return this._serverObject; }
 
+  get labelingModes() {
+    return this.LABELING_MODES;
+  }
 }

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -55,6 +55,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
   }
   get seasonality(): number { return this._serverObject.seasonality; }
 
+  // TODO: merge seasonality and hasSeasonality
   set hasSeasonality(val: boolean) {
     if(val) {
       this.seasonality = 1000;

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -8,7 +8,7 @@ const DEFAULTS = {
   detectorType: DetectorType.ANOMALY,
   type: 'ANOMALY',
   alpha: 0.5,
-  confidence: 0,
+  confidence: 1,
   seasonality: 0
 };
 

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -14,7 +14,7 @@ const DEFAULTS = {
 
 export class AnomalyAnalyticUnit extends AnalyticUnit {
   // TODO: timespan type
-  private _seasonalityPeriod: any = {};
+  public seasonalityPeriod: any = {};
 
   constructor(_serverObject?: any) {
     super(_serverObject);
@@ -34,9 +34,8 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
 
   public updateSeasonality() {
     let seasonalityObj = {};
-    seasonalityObj[this._seasonalityPeriod.unit] = this._seasonalityPeriod.value;
+    seasonalityObj[this.seasonalityPeriod.unit] = this.seasonalityPeriod.value;
     this.seasonality = moment.duration(seasonalityObj).asMilliseconds();
-    this._seasonalityPeriod = msToPeriod(this.seasonality);
   }
 
   set alpha(val: number) { this._serverObject.alpha = val; }
@@ -45,7 +44,10 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
   set confidence(val: number) { this._serverObject.confidence = val; }
   get confidence(): number { return this._serverObject.confidence; }
 
-  set seasonality(val: number) { this._serverObject.seasonality = val; }
+  set seasonality(val: number) { 
+    this._serverObject.seasonality = val;
+    this.seasonalityPeriod = msToPeriod(this.seasonality);
+  }
   get seasonality(): number { return this._serverObject.seasonality; }
 
   set hasSeasonality(val: boolean) {
@@ -57,18 +59,5 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
   }
   get hasSeasonality(): boolean {
     return this.seasonality > 0;
-  }
-
-  get seasonalitySpanValue() {
-    return this._seasonalityPeriod.value;
-  }
-  set seasonalitySpanValue(val: number) {
-    this._seasonalityPeriod.value = val;
-  }
-  get seasonalitySpanUnit() {
-    return this._seasonalityPeriod.unit;
-  }
-  set seasonalitySpanUnit(val: string) {
-    this._seasonalityPeriod.unit = val;
   }
 }

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -1,4 +1,4 @@
-import { AnalyticUnit, DetectorType } from './analytic_unit';
+import { AnalyticUnit, DetectorType, LabelingMode } from './analytic_unit';
 import { msToPeriod } from './utils';
 
 import _ from 'lodash';
@@ -19,6 +19,11 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
   constructor(_serverObject?: any) {
     super(_serverObject);
     _.defaults(this._serverObject, DEFAULTS);
+
+    this.LABELING_MODES = [
+      { name: 'Label Negative', value: LabelingMode.DELETING },
+      { name: 'Unlabel', value: LabelingMode.UNLABELING }
+    ];
     this.updateSeasonality();
   }
 

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -1,19 +1,25 @@
 import { AnalyticUnit, DetectorType } from './analytic_unit';
+import { msToPeriod } from './utils';
 
 import _ from 'lodash';
+import moment from 'moment';
 
 const DEFAULTS = {
   detectorType: DetectorType.ANOMALY,
   type: 'ANOMALY',
   alpha: 0.5,
-  confidence: 1
+  confidence: 0,
+  seasonality: 0
 };
 
 export class AnomalyAnalyticUnit extends AnalyticUnit {
 
+  private _seasonalityPeriod = { value: 1, unit: 'seconds' };
+
   constructor(_serverObject?: any) {
     super(_serverObject);
     _.defaults(this._serverObject, DEFAULTS);
+    this.updateSeasonality();
   }
 
   toJSON() {
@@ -21,8 +27,16 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
     return {
       ...baseJSON,
       alpha: this.alpha,
-      confidence: this.confidence
+      confidence: this.confidence,
+      seasonality: this.seasonality
     };
+  }
+
+  public updateSeasonality() {
+    let seasonalityObj = {};
+    seasonalityObj[this._seasonalityPeriod.unit] = this._seasonalityPeriod.value;
+    this.seasonality = moment.duration(seasonalityObj).asMilliseconds();
+    this._seasonalityPeriod = msToPeriod(this.seasonality);
   }
 
   set alpha(val: number) { this._serverObject.alpha = val; }
@@ -30,4 +44,31 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
 
   set confidence(val: number) { this._serverObject.confidence = val; }
   get confidence(): number { return this._serverObject.confidence; }
+
+  set seasonality(val: number) { this._serverObject.seasonality = val; }
+  get seasonality(): number { return this._serverObject.seasonality; }
+
+  set hasSeasonality(val: boolean) {
+    if(val) {
+      this.seasonality = 1000;
+    } else {
+      this.seasonality = 0;
+    }
+  }
+  get hasSeasonality(): boolean {
+    return this.seasonality > 0;
+  }
+
+  get seasonalitySpanValue() {
+    return this._seasonalityPeriod.value;
+  }
+  set seasonalitySpanValue(val: number) {
+    this._seasonalityPeriod.value = val;
+  }
+  get seasonalitySpanUnit() {
+    return this._seasonalityPeriod.unit;
+  }
+  set seasonalitySpanUnit(val: string) {
+    this._seasonalityPeriod.unit = val;
+  }
 }

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -13,8 +13,8 @@ const DEFAULTS = {
 };
 
 export class AnomalyAnalyticUnit extends AnalyticUnit {
-
-  private _seasonalityPeriod = { value: 1, unit: 'seconds' };
+  // TODO: timespan type
+  private _seasonalityPeriod: any = {};
 
   constructor(_serverObject?: any) {
     super(_serverObject);

--- a/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/anomaly_analytic_unit.ts
@@ -20,15 +20,16 @@ const DEFAULTS = {
   }
 };
 
+const LABELING_MODES = [
+  { name: 'Label Negative', value: LabelingMode.DELETING },
+  { name: 'Unlabel', value: LabelingMode.UNLABELING }
+];
+
 export class AnomalyAnalyticUnit extends AnalyticUnit {
+
   constructor(_serverObject?: any) {
     super(_serverObject);
     _.defaults(this._serverObject, DEFAULTS);
-
-    this.LABELING_MODES = [
-      { name: 'Label Negative', value: LabelingMode.DELETING },
-      { name: 'Unlabel', value: LabelingMode.UNLABELING }
-    ];
   }
 
   toJSON() {
@@ -67,5 +68,9 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
   }
   get hasSeasonality(): boolean {
     return this.seasonality > 0;
+  }
+
+  get labelingModes() {
+    return LABELING_MODES;
   }
 }

--- a/src/panel/graph_panel/models/analytic_units/pattern_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/pattern_analytic_unit.ts
@@ -1,4 +1,4 @@
-import { AnalyticUnit, DetectorType } from './analytic_unit';
+import { AnalyticUnit, DetectorType, LabelingMode } from './analytic_unit';
 
 import _ from 'lodash';
 
@@ -12,6 +12,12 @@ export class PatternAnalyticUnit extends AnalyticUnit {
   constructor(_serverObject?: any) {
     super(_serverObject);
     _.defaults(this._serverObject, DEFAULTS);
+
+    this.LABELING_MODES = [
+      { name: 'Label Positive', value: LabelingMode.LABELING },
+      { name: 'Label Negative', value: LabelingMode.DELETING },
+      { name: 'Unlabel', value: LabelingMode.UNLABELING }
+    ];
   }
 
   toJSON() {

--- a/src/panel/graph_panel/models/analytic_units/pattern_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/pattern_analytic_unit.ts
@@ -7,17 +7,17 @@ const DEFAULTS = {
   type: 'GENERAL'
 };
 
+const LABELING_MODES = [
+  { name: 'Label Positive', value: LabelingMode.LABELING },
+  { name: 'Label Negative', value: LabelingMode.DELETING },
+  { name: 'Unlabel', value: LabelingMode.UNLABELING }
+];
+
 export class PatternAnalyticUnit extends AnalyticUnit {
 
   constructor(_serverObject?: any) {
     super(_serverObject);
     _.defaults(this._serverObject, DEFAULTS);
-
-    this.LABELING_MODES = [
-      { name: 'Label Positive', value: LabelingMode.LABELING },
-      { name: 'Label Negative', value: LabelingMode.DELETING },
-      { name: 'Unlabel', value: LabelingMode.UNLABELING }
-    ];
   }
 
   toJSON() {
@@ -25,5 +25,9 @@ export class PatternAnalyticUnit extends AnalyticUnit {
     return {
       ...baseJSON
     };
+  }
+
+  get labelingModes() {
+    return LABELING_MODES;
   }
 }

--- a/src/panel/graph_panel/models/analytic_units/threshold_analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/threshold_analytic_unit.ts
@@ -19,6 +19,8 @@ const DEFAULTS = {
   condition: Condition.ABOVE_OR_EQUAL
 };
 
+const LABELING_MODES = [];
+
 export class ThresholdAnalyticUnit extends AnalyticUnit {
 
   constructor(_serverObject?: any) {
@@ -40,4 +42,8 @@ export class ThresholdAnalyticUnit extends AnalyticUnit {
 
   set condition(val: Condition) { this._serverObject.condition = val; }
   get condition(): Condition { return this._serverObject.condition; }
+
+  get labelingModes() {
+    return LABELING_MODES;
+  }
 }

--- a/src/panel/graph_panel/models/analytic_units/utils.ts
+++ b/src/panel/graph_panel/models/analytic_units/utils.ts
@@ -16,36 +16,3 @@ export function createAnalyticUnit(serverObject: any): AnalyticUnit {
       throw new Error(`Can't create analytic unit with type "${detectorType}"`);
   }
 }
-
-export function msToPeriod(ms: number) {
-  if(ms < 60000) {
-    // Less than 1 min
-    return {
-      value: Math.round(ms / 1000),
-      unit: 'seconds'
-    };
-  } else if(ms < 3600000) {
-    // Less than 1 hour, divide in minutes
-    return {
-      value: Math.round(ms / 60000),
-      unit: 'minutes'
-    };
-  } else if(ms < 86400000) {
-    // Less than one day, divide in hours
-    return {
-      value: Math.round(ms / 3600000),
-      unit: 'hours'
-    };
-  } else if(ms < 31536000000) {
-    // Less than one year, divide in days
-    return {
-      value: Math.round(ms / 86400000),
-      unit: 'days'
-    };
-  }
-
-  return {
-    value: Math.round(ms / 31536000000),
-    unit: 'years'
-  };
-}

--- a/src/panel/graph_panel/models/analytic_units/utils.ts
+++ b/src/panel/graph_panel/models/analytic_units/utils.ts
@@ -16,3 +16,36 @@ export function createAnalyticUnit(serverObject: any): AnalyticUnit {
       throw new Error(`Can't create analytic unit with type "${detectorType}"`);
   }
 }
+
+export function msToPeriod(ms: number) {
+  if(ms < 60000) {
+    // Less than 1 min
+    return {
+      value: Math.round(ms / 1000),
+      unit: 'seconds'
+    };
+  } else if(ms < 3600000) {
+    // Less than 1 hour, divide in minutes
+    return {
+      value: Math.round(ms / 60000),
+      unit: 'minutes'
+    };
+  } else if(ms < 86400000) {
+    // Less than one day, divide in hours
+    return {
+      value: Math.round(ms / 3600000),
+      unit: 'hours'
+    };
+  } else if(ms < 31536000000) {
+    // Less than one year, divide in days
+    return {
+      value: Math.round(ms / 86400000),
+      unit: 'days'
+    };
+  }
+
+  return {
+    value: Math.round(ms / 31536000000),
+    unit: 'years'
+  };
+}

--- a/src/panel/graph_panel/models/analytic_units/utils.ts
+++ b/src/panel/graph_panel/models/analytic_units/utils.ts
@@ -18,6 +18,7 @@ export function createAnalyticUnit(serverObject: any): AnalyticUnit {
 }
 
 export function msToPeriod(ms: number) {
+  console.log(ms)
   if(ms < 60000) {
     // Less than 1 min
     return {

--- a/src/panel/graph_panel/models/analytic_units/utils.ts
+++ b/src/panel/graph_panel/models/analytic_units/utils.ts
@@ -18,7 +18,6 @@ export function createAnalyticUnit(serverObject: any): AnalyticUnit {
 }
 
 export function msToPeriod(ms: number) {
-  console.log(ms)
   if(ms < 60000) {
     // Less than 1 min
     return {

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -252,9 +252,10 @@
         >
           <label class="gf-form-label width-9"> Seasonality Period </label>
           <input
-            type="text" class="gf-form-input width-5"
+            type="number" class="gf-form-input width-5"
             ng-model="analyticUnit.seasonalityPeriod.value"
             ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
+            min="0"
           >
         </div>
 

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -153,8 +153,11 @@
         >
 
         <div class="gf-form-select-wrapper"
-          ng-hide="analyticUnit.selected"
-          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
+          ng-if="
+            analyticUnit.detectorType === 'anomaly' && 
+            analyticUnit.hasSeasonality &&
+            !analyticUnit.selected
+          "
         >
           <!-- TODO: move periods from ng-options -->
           <select class="gf-form-input width-8"
@@ -164,7 +167,7 @@
           />
         </div>
 
-        <label class="gf-form-label" ng-hide="analyticUnit.selected">
+        <label class="gf-form-label" ng-if="!analyticUnit.selected">
           <a
             ng-if="analyticUnit.visible"
             bs-tooltip="'Hide. It`s visible now.'"
@@ -202,11 +205,7 @@
 
         <select class="gf-form-input width-12"
           ng-model="ctrl.analyticsController.labelingMode"
-          ng-options="type.value as type.name for type in [
-            { name:'Label Positive', value: 'LABELING' },
-            { name:'Label Negative', value: 'DELETING' },
-            { name:'Unlabel', value: 'UNLABELING' }
-          ]"
+          ng-options="type.value as type.name for type in analyticUnit.labelingModes"
           ng-if="
             (analyticUnit.detectorType === 'pattern' ||
             (analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality)) &&

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -1,7 +1,7 @@
 <div class="gf-form-group">
   <div class="gf-form">
     <label class="gf-form-label">Select Hastic datasource</label>
-    <select class="gf-form-input max-width-15"
+    <select class="gf-form-input width-15"
       ng-model="ctrl.panel.hasticDatasource"
       ng-options="ds.id as ds.name for ds in ctrl.hasticDatasources"
       ng-change="ctrl.onHasticDatasourceChange()"
@@ -20,276 +20,281 @@
 
   <div ng-if="ctrl.analyticsController.serverStatus === true && !ctrl.analyticsController.loading">
     <h5> Analytic Units </h5>
-    <div class="editor-row">
-      <div class="gf-form" ng-repeat="analyticUnit in ctrl.analyticsController.analyticUnits">
+    <div ng-repeat="analyticUnit in ctrl.analyticsController.analyticUnits">
+      <div class="gf-form-inline">
+        <div class="gf-form">
+          <label class="gf-form-label width-5">
+            <i class="fa fa-info" bs-tooltip="'Analytic unit id: ' + analyticUnit.id"></i>
+            &nbsp; Name
+          </label>
+          <input
+            type="text" class="gf-form-input width-15"
+            ng-model="analyticUnit.name"
+            ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
+          >
+        </div>
 
-        <label class="gf-form-label width-5">
-          <i class="fa fa-info" bs-tooltip="'Analytic unit id: ' + analyticUnit.id"></i>
-          &nbsp; Name
-        </label>
-        <input
-          type="text" class="gf-form-input max-width-15"
-          ng-model="analyticUnit.name"
-          ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
+        <div class="gf-form">
+          <label class="gf-form-label width-5"> Type </label>
+          <div class="gf-form-select-wrapper">
+            <select class="gf-form-input width-10"
+              ng-model="analyticUnit.type"
+              ng-options="type.value as type.name for type in ctrl.analyticUnitTypes[analyticUnit.detectorType]"
+              ng-disabled="true"
+            />
+          </div>
+        </div>
+
+        <div class="gf-form">
+          <label class="gf-form-label width-8"> Positive Color </label>
+          <span class="gf-form-label">
+            <color-picker
+              color="analyticUnit.labeledColor"
+              onChange="ctrl.onColorChange.bind(ctrl, analyticUnit.id, false)"
+            />
+          </span>
+        </div>
+
+        <div class="gf-form"
+          ng-if="analyticUnit.detectorType === 'pattern' || analyticUnit.detectorType === 'anomaly'"
         >
+          <label class="gf-form-label width-8"> Negative Color </label>
+          <span class="gf-form-label">
+            <color-picker
+              color="analyticUnit.deletedColor"
+              onChange="ctrl.onColorChange.bind(ctrl, analyticUnit.id, true)"
+            />
+          </span>
+        </div>
 
-        <label class="gf-form-label width-4"> Type </label>
-        <div class="gf-form-select-wrapper">
-          <select class="gf-form-input width-10"
-            ng-model="analyticUnit.type"
-            ng-options="type.value as type.name for type in ctrl.analyticUnitTypes[analyticUnit.detectorType]"
-            ng-disabled="true"
+        <div class="gf-form" ng-if="analyticUnit.visible">
+          <!-- TODO: Remove hack with "margin-bottom: 0" -->
+          <gf-form-switch
+            class="gf-form"
+            style="margin-bottom: 0"
+            label="Inspect"
+            label-class="width-7"
+            on-change="ctrl.onToggleInspect(analyticUnit.id)"
+            checked="analyticUnit.inspect"
           />
         </div>
 
-        <!--
-        <label class="gf-form-label width-6"> Confidence </label>
-        <input
-          type="number" class="gf-form-input width-5 ng-valid ng-scope ng-empty ng-dirty ng-valid-number ng-touched"
-          placeholder="auto" bs-tooltip="'Override automatic decimal precision for legend and tooltips'"
-          data-placement="right" ng-model="ctrl.panel.decimals" ng-change="ctrl.render()" ng-model-onblur="" data-original-title="" title=""
-        />
-        -->
-
-        <label class="gf-form-label width-8"> Positive Color </label>
-        <span class="gf-form-label">
-          <color-picker
-            color="analyticUnit.labeledColor"
-            onChange="ctrl.onColorChange.bind(ctrl, analyticUnit.id, false)"
-          />
-        </span>
-
-        <!-- Hack to avoid Grafana's .gf-form-label + .gf-form-label css. Fix for https://github.com/hastic/hastic-grafana-app/issues/192 -->
-        <div ng-if="analyticUnit.detectorType === 'pattern'"></div>
-
-        <label ng-if="analyticUnit.detectorType === 'pattern'" class="gf-form-label width-8"> Negative Color </label>
-        <span ng-if="analyticUnit.detectorType === 'pattern'"  class="gf-form-label">
-          <color-picker
-            color="analyticUnit.deletedColor"
-            onChange="ctrl.onColorChange.bind(ctrl, analyticUnit.id, true)"
-          />
-        </span>
-
-        <!-- TODO: move analytic-unit-specific fields rendering to class -->
-        <select class="gf-form-input width-9"
-          ng-if="analyticUnit.detectorType === 'threshold'"
-          ng-model="analyticUnit.condition"
-          ng-options="type for type in ctrl.analyticsController.conditions"
-          ng-change="ctrl.onAnalyticUnitChange(analyticUnit)"
-        />
-        <input class="gf-form-input width-5"
-          ng-if="
-            analyticUnit.detectorType === 'threshold' &&
-            analyticUnit.condition !== 'NO_DATA'
-          "
-          type="number"
-          ng-model="analyticUnit.value"
-          ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
-        />
-
-        <label
-          class="gf-form-label width-4"
-          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
-        >
-          Alpha
-        </label>
-        <input class="gf-form-input max-width-4"
-          ng-hide="analyticUnit.selected"
-          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
-          min="0"
-          max="1"
-          type="number"
-          ng-model="analyticUnit.alpha"
-          ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
-        />
-
-        <label
-          class="gf-form-label width-6"
-          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
-        >
-          Confidence
-        </label>
-        <input class="gf-form-input max-width-4"
-          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
-          min="0"
-          type="number"
-          ng-model="analyticUnit.confidence"
-          ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
-        />
-
-        <!-- TODO: Remove hack with "margin-bottom: 0" -->
-        <gf-form-switch ng-if="analyticUnit.visible"
+        <div
           class="gf-form"
-          style="margin-bottom: 0"
-          label="Inspect"
-          label-class="width-5"
-          on-change="ctrl.onToggleInspect(analyticUnit.id)"
-          checked="analyticUnit.inspect"
-        />
-
-        <!-- TODO: Remove hack with "margin-bottom: 0" -->
-        <gf-form-switch 
-          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
-          class="gf-form"
-          style="margin-bottom: 0"
-          label="Seasonality"
-          label-class="width-6"
-          on-change="ctrl.onAnalyticUnitChange(analyticUnit)"
-          checked="analyticUnit.hasSeasonality"
-        />
-
-        <label
-          ng-hide="analyticUnit.selected"
-          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality && !analyticUnit.selected"
-          class="gf-form-label width-9"
-        >
-          Seasonality Period
-        </label>
-        <input
-          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality && !analyticUnit.selected"
-          type="text" class="gf-form-input max-width-5"
-          ng-model="analyticUnit.seasonalityPeriod.value"
-          ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
-        >
-
-        <div class="gf-form-select-wrapper"
           ng-if="
-            analyticUnit.detectorType === 'anomaly' && 
-            analyticUnit.hasSeasonality &&
-            !analyticUnit.selected
+            analyticUnit.detectorType === 'pattern' ||
+            (analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality)
           "
         >
-          <!-- TODO: move periods from ng-options -->
-          <select class="gf-form-input width-8"
-            ng-model="analyticUnit.seasonalityPeriod.unit"
-            ng-change="ctrl.onSeasonalityChange(analyticUnit.id)"
-            ng-options="type for type in ['seconds', 'minutes', 'days', 'hours', 'days', 'years']"
+          <label
+            class="gf-form-label pointer"
+            ng-if="!analyticUnit.selected"
+            ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
+            ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
+            ng-disabled="analyticUnit.status === 'LEARNING'"
+          >
+            <i class="fa fa-bar-chart" ng-if="!analyticUnit.saving"></i>
+            <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
+            Label
+          </label>
+          <select class="gf-form-input width-12"
+            ng-if="analyticUnit.selected && !analyticUnit.saving"
+            ng-model="ctrl.analyticsController.labelingMode"
+            ng-options="type.value as type.name for type in analyticUnit.labelingModes"
+            ng-disabled="analyticUnit.status === 'LEARNING'"
           />
         </div>
 
-        <label class="gf-form-label" ng-if="!analyticUnit.selected">
-          <a
-            ng-if="analyticUnit.visible"
-            bs-tooltip="'Hide. It`s visible now.'"
-            ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
-            class="pointer"
+        <div class="gf-form" ng-if="!analyticUnit.selected">
+          <label class="gf-form-label">
+            <a
+              ng-if="analyticUnit.visible"
+              bs-tooltip="'Hide. It`s visible now.'"
+              ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
+              class="pointer"
+            >
+              <i class="fa fa-eye"></i>
+            </a>
+
+            <a
+              ng-if="!analyticUnit.visible"
+              bs-tooltip="'Show. It`s hidden now.'"
+              ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
+              class="pointer"
+            >
+              <i class="fa fa-eye-slash"></i>
+            </a>
+          </label>
+        </div>
+
+        <div class="gf-form">
+          <label class="gf-form-label">
+            <a
+              ng-if="!analyticUnit.selected"
+              ng-click="ctrl.onRemove(analyticUnit.id)"
+              class="pointer"
+            >
+              <i class="fa fa-trash"></i>
+            </a>
+
+            <a
+              ng-if="analyticUnit.selected"
+              ng-click="ctrl.onCancelLabeling(analyticUnit.id)"
+              class="pointer"
+            >
+              <i class="fa fa-ban"></i>
+            </a>
+          </label>
+        </div>
+
+        <div class="gf-form" ng-if="analyticUnit.selected && !analyticUnit.saving">
+          <!-- Standard way to add conditions to ng-style: https://stackoverflow.com/a/29470439 -->
+          <label
+            class="gf-form-label"
+            ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
+            ng-disabled="analyticUnit.status === 'LEARNING'"
           >
-            <i class="fa fa-eye"></i>
-          </a>
+            <a class="pointer"
+              ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
+              ng-disabled="analyticUnit.status === 'LEARNING'"
+            >
+              <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
+              <b ng-if="!analyticUnit.saving"> Detect </b>
+              <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
+              </a>
+          </label>
+        </div>
 
-          <a
-            ng-if="!analyticUnit.visible"
-            bs-tooltip="'Show. It`s hidden now.'"
-            ng-click="ctrl.onToggleVisibility(analyticUnit.id)"
-            class="pointer"
-          >
-            <i class="fa fa-eye-slash"></i>
-          </a>
-        </label>
-
-        <label
-          class="gf-form-label pointer"
-          ng-if="
-            (analyticUnit.detectorType === 'pattern' ||
-            (analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality)) &&
-            !analyticUnit.selected
-          "
-          ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
-          ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
-          ng-disabled="analyticUnit.status === 'LEARNING'"
-        >
-          <i class="fa fa-bar-chart" ng-if="!analyticUnit.saving"></i>
-          <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
-          Label
-        </label>
-
-        <select class="gf-form-input width-12"
-          ng-model="ctrl.analyticsController.labelingMode"
-          ng-options="type.value as type.name for type in analyticUnit.labelingModes"
-          ng-if="
-            (analyticUnit.detectorType === 'pattern' ||
-            (analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality)) &&
-            analyticUnit.selected &&
-            !analyticUnit.saving
-          "
-          ng-disabled="analyticUnit.status === 'LEARNING'"
-        />
-
-        <label class="gf-form-label"
+        <div class="gf-form"
           ng-if="
             analyticUnit.detectorType === 'threshold' ||
             (analyticUnit.detectorType === 'anomaly' && !analyticUnit.hasSeasonality)
           "
         >
-          <a class="pointer" ng-click="ctrl.runDetectInCurrentRange(analyticUnit.id)">
-            <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
-            <b ng-if="!analyticUnit.saving"> Detect </b>
-            <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
-          </a>
-        </label>
-
-        <!-- Standard way to add conditions to ng-style: https://stackoverflow.com/a/29470439 -->
-        <label
-          class="gf-form-label"
-          ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
-          ng-if="analyticUnit.selected && !analyticUnit.saving"
-          ng-disabled="analyticUnit.status === 'LEARNING'"
-        >
-          <a class="pointer"
-            ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
-            ng-disabled="analyticUnit.status === 'LEARNING'"
-          >
-            <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
-            <b ng-if="!analyticUnit.saving"> Detect </b>
-            <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
+          <label class="gf-form-label">
+            <a class="pointer" ng-click="ctrl.runDetectInCurrentRange(analyticUnit.id)">
+              <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
+              <b ng-if="!analyticUnit.saving"> Detect </b>
+              <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
             </a>
-        </label>
+          </label>
+        </div>
 
-        <label class="gf-form-label">
-          <a
-            ng-if="!analyticUnit.selected"
-            ng-click="ctrl.onRemove(analyticUnit.id)"
-            class="pointer"
+        <div class="gf-form">
+          <label>
+            <i ng-if="analyticUnit.status === 'READY'" class="grafana-tip fa fa-check-circle ng-scope" bs-tooltip="'Ready'"></i>
+            <i ng-if="analyticUnit.status === 'LEARNING'" class="grafana-tip fa fa-leanpub ng-scope" bs-tooltip="'Learning'"></i>
+            <i ng-if="analyticUnit.status === 'PENDING'" class="grafana-tip fa fa-list-ul ng-scope" bs-tooltip="'Pending'"></i>
+            <i ng-if="analyticUnit.status === 'FAILED'" class="grafana-tip fa fa-exclamation-circle ng-scope" bs-tooltip="'Error: ' + analyticUnit.error"></i>
+          </label>
+        </div>
+      </div>
+
+      <div class="gf-form-inline">
+        <div class="gf-form width-20"/>
+        <!-- TODO: move analytic-unit-specific fields rendering to class -->
+        <div class="gf-form" ng-if="analyticUnit.detectorType === 'threshold'">
+          <label class="gf-form-label width-5"> Condition </label>
+          <select class="gf-form-input width-5"
+            ng-class="{
+              'width-5': analyticUnit.condition !== 'NO_DATA',
+              'width-10': analyticUnit.condition === 'NO_DATA'
+            }"
+            ng-model="analyticUnit.condition"
+            ng-options="type for type in ctrl.analyticsController.conditions"
+            ng-change="ctrl.onAnalyticUnitChange(analyticUnit)"
+          />
+          <input class="gf-form-input width-5"
+            ng-if="analyticUnit.condition !== 'NO_DATA'"
+            type="number"
+            ng-model="analyticUnit.value"
+            ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
+          />
+        </div>
+
+        <div class="gf-form" ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected">
+          <label class="gf-form-label width-5"> Alpha </label>
+          <input class="gf-form-input width-10"
+            ng-hide="analyticUnit.selected"
+            min="0"
+            max="1"
+            type="number"
+            ng-model="analyticUnit.alpha"
+            ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
+          />
+        </div>
+
+        <div class="gf-form" ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected">
+          <label class="gf-form-label width-6"> Confidence </label>
+          <input class="gf-form-input width-5"
+            min="0"
+            type="number"
+            ng-model="analyticUnit.confidence"
+            ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
+          />
+        </div>
+
+        <div class="gf-form" ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected">
+          <!-- TODO: Remove hack with "margin-bottom: 0" -->
+          <gf-form-switch
+            class="gf-form"
+            style="margin-bottom: 0"
+            label="Seasonality"
+            label-class="width-7"
+            on-change="ctrl.onAnalyticUnitChange(analyticUnit)"
+            checked="analyticUnit.hasSeasonality"
+          />
+        </div>
+
+        <div
+          class="gf-form"
+          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality && !analyticUnit.selected"
+        >
+          <label class="gf-form-label width-9"> Seasonality Period </label>
+          <input
+            type="text" class="gf-form-input width-5"
+            ng-model="analyticUnit.seasonalityPeriod.value"
+            ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
           >
-            <i class="fa fa-trash"></i>
-          </a>
+        </div>
 
-          <a
-            ng-if="analyticUnit.selected"
-            ng-click="ctrl.onCancelLabeling(analyticUnit.id)"
-            class="pointer"
-          >
-            <i class="fa fa-ban"></i>
-          </a>
-        </label>
-
-        <label>
-          <i ng-if="analyticUnit.status === 'READY'" class="grafana-tip fa fa-check-circle ng-scope" bs-tooltip="'Ready'"></i>
-          <i ng-if="analyticUnit.status === 'LEARNING'" class="grafana-tip fa fa-leanpub ng-scope" bs-tooltip="'Learning'"></i>
-          <i ng-if="analyticUnit.status === 'PENDING'" class="grafana-tip fa fa-list-ul ng-scope" bs-tooltip="'Pending'"></i>
-          <i ng-if="analyticUnit.status === 'FAILED'" class="grafana-tip fa fa-exclamation-circle ng-scope" bs-tooltip="'Error: ' + analyticUnit.error"></i>
-        </label>
+        <div class="gf-form"
+          ng-if="
+            analyticUnit.detectorType === 'anomaly' &&
+            analyticUnit.hasSeasonality &&
+            !analyticUnit.selected
+          "
+        >
+          <div class="gf-form-select-wrapper">
+            <!-- TODO: move periods from ng-options -->
+            <select class="gf-form-input width-8"
+              ng-model="analyticUnit.seasonalityPeriod.unit"
+              ng-change="ctrl.onSeasonalityChange(analyticUnit.id)"
+              ng-options="type for type in ['seconds', 'minutes', 'days', 'hours', 'days', 'years']"
+            />
+          </div>
+        </div>
       </div>
     </div>
 
     <div class="editor-row" ng-if="ctrl.analyticsController.creatingNew">
       <div class="gf-form">
-        <label class="gf-form-label width-4"> Name </label>
+        <label class="gf-form-label width-5"> Name </label>
         <input
-          type="text" class="gf-form-input max-width-15"
+          type="text" class="gf-form-input width-15"
           ng-model="ctrl.analyticsController.newAnalyticUnit.name"
         >
 
         <label class="gf-form-label width-8"> Detector Type </label>
         <div class="gf-form-select-wrapper">
-          <select class="gf-form-input width-10"
+          <select class="gf-form-input width-7"
             ng-model="ctrl.analyticsController.newAnalyticUnit.detectorType"
             ng-options="analyticUnitDetectorType for analyticUnitDetectorType in ctrl.analyticUnitDetectorTypes"
             ng-change="ctrl.analyticsController.onAnalyticUnitDetectorChange(ctrl.analyticUnitTypes);"
           />
         </div>
 
-        <label class="gf-form-label width-8"> Type </label>
+        <label class="gf-form-label width-5"> Type </label>
         <div class="gf-form-select-wrapper">
           <select class="gf-form-input width-10"
             ng-model="ctrl.analyticsController.newAnalyticUnit.type"
@@ -315,7 +320,7 @@
         Add Analytic Unit
       </button>
     </div>
-    <div class="gf-form-button-row">
+    <div class="gf-form-button-row" ng-if="ctrl.analyticsController.analyticUnits.length > 0">
       <button class="gf-form-label width-12 pointer" ng-click="ctrl.redetectAll()">
         Re-detect all analytic units
       </button>

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -87,8 +87,8 @@
           ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
         />
 
-        <label class="gf-form-label width-6" ng-if="analyticUnit.detectorType === 'anomaly'"> Alpha </label>
-        <input class="gf-form-input width-5"
+        <label class="gf-form-label width-4" ng-if="analyticUnit.detectorType === 'anomaly'"> Alpha </label>
+        <input class="gf-form-input max-width-4"
           ng-if="analyticUnit.detectorType === 'anomaly'"
           min="0"
           max="1"
@@ -98,7 +98,7 @@
         />
 
         <label class="gf-form-label width-6" ng-if="analyticUnit.detectorType === 'anomaly'"> Confidence </label>
-        <input class="gf-form-input width-5"
+        <input class="gf-form-input max-width-4"
           ng-if="analyticUnit.detectorType === 'anomaly'"
           min="0"
           type="number"
@@ -115,6 +115,40 @@
           on-change="ctrl.onToggleInspect(analyticUnit.id)"
           checked="analyticUnit.inspect"
         />
+
+        <!-- TODO: Remove hack with "margin-bottom: 0" -->
+        <gf-form-switch ng-if="analyticUnit.detectorType === 'anomaly'"
+          class="gf-form"
+          style="margin-bottom: 0"
+          label="Seasonality"
+          label-class="width-6"
+          on-change="ctrl.onAnalyticUnitChange(analyticUnit)"
+          checked="analyticUnit.hasSeasonality"
+        />
+
+        <label
+          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
+          class="gf-form-label width-9"
+        >
+          Seasonality Period
+        </label>
+        <input
+          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
+          type="text" class="gf-form-input max-width-5"
+          ng-model="analyticUnit.seasonalitySpanValue"
+          ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
+        >
+
+        <div class="gf-form-select-wrapper"
+          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
+        >
+          <!-- TODO: move timespans from ng-options -->
+          <select class="gf-form-input width-8"
+            ng-model="analyticUnit.seasonalitySpanUnit"
+            ng-change="ctrl.onSeasonalityChange(analyticUnit.id)"
+            ng-options="type for type in ['seconds', 'minutes', 'days', 'hours', 'days', 'years']"
+          />
+        </div>
 
         <label class="gf-form-label" ng-hide="analyticUnit.selected">
           <a
@@ -136,19 +170,13 @@
           </a>
         </label>
 
-        <label class="gf-form-label"
-          ng-if="analyticUnit.detectorType === 'threshold' || analyticUnit.detectorType === 'anomaly'"
-        >
-          <a class="pointer" ng-click="ctrl.runDetectInCurrentRange(analyticUnit.id)">
-            <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
-            <b ng-if="!analyticUnit.saving"> Detect </b>
-            <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
-          </a>
-        </label>
-
         <label
           class="gf-form-label pointer"
-          ng-if="analyticUnit.detectorType === 'pattern' && !analyticUnit.selected"
+          ng-if="
+            (analyticUnit.detectorType === 'pattern' ||
+            (analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality)) &&
+            !analyticUnit.selected
+          "
           ng-style="analyticUnit.status === 'LEARNING' && { 'cursor': 'not-allowed' }"
           ng-click="ctrl.onToggleLabelingMode(analyticUnit.id)"
           ng-disabled="analyticUnit.status === 'LEARNING'"
@@ -168,6 +196,19 @@
           ng-if="analyticUnit.selected && !analyticUnit.saving"
           ng-disabled="analyticUnit.status === 'LEARNING'"
         />
+
+        <label class="gf-form-label"
+          ng-if="
+            analyticUnit.detectorType === 'threshold' ||
+            (analyticUnit.detectorType === 'anomaly' && !analyticUnit.hasSeasonality)
+          "
+        >
+          <a class="pointer" ng-click="ctrl.runDetectInCurrentRange(analyticUnit.id)">
+            <i class="fa fa-spinner fa-spin" ng-if="analyticUnit.saving"></i>
+            <b ng-if="!analyticUnit.saving"> Detect </b>
+            <b ng-if="analyticUnit.saving" ng-disabled="true"> saving... </b>
+          </a>
+        </label>
 
         <!-- Standard way to add conditions to ng-style: https://stackoverflow.com/a/29470439 -->
         <label

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -87,9 +87,15 @@
           ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
         />
 
-        <label class="gf-form-label width-4" ng-if="analyticUnit.detectorType === 'anomaly'"> Alpha </label>
+        <label
+          class="gf-form-label width-4"
+          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
+        >
+          Alpha
+        </label>
         <input class="gf-form-input max-width-4"
-          ng-if="analyticUnit.detectorType === 'anomaly'"
+          ng-hide="analyticUnit.selected"
+          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
           min="0"
           max="1"
           type="number"
@@ -97,9 +103,14 @@
           ng-blur="ctrl.onAnalyticUnitChange(analyticUnit)"
         />
 
-        <label class="gf-form-label width-6" ng-if="analyticUnit.detectorType === 'anomaly'"> Confidence </label>
+        <label
+          class="gf-form-label width-6"
+          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
+        >
+          Confidence
+        </label>
         <input class="gf-form-input max-width-4"
-          ng-if="analyticUnit.detectorType === 'anomaly'"
+          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
           min="0"
           type="number"
           ng-model="analyticUnit.confidence"
@@ -117,7 +128,8 @@
         />
 
         <!-- TODO: Remove hack with "margin-bottom: 0" -->
-        <gf-form-switch ng-if="analyticUnit.detectorType === 'anomaly'"
+        <gf-form-switch 
+          ng-if="analyticUnit.detectorType === 'anomaly' && !analyticUnit.selected"
           class="gf-form"
           style="margin-bottom: 0"
           label="Seasonality"
@@ -127,19 +139,21 @@
         />
 
         <label
-          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
+          ng-hide="analyticUnit.selected"
+          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality && !analyticUnit.selected"
           class="gf-form-label width-9"
         >
           Seasonality Period
         </label>
         <input
-          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
+          ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality && !analyticUnit.selected"
           type="text" class="gf-form-input max-width-5"
           ng-model="analyticUnit.seasonalityPeriod.value"
           ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
         >
 
         <div class="gf-form-select-wrapper"
+          ng-hide="analyticUnit.selected"
           ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
         >
           <!-- TODO: move periods from ng-options -->
@@ -193,7 +207,12 @@
             { name:'Label Negative', value: 'DELETING' },
             { name:'Unlabel', value: 'UNLABELING' }
           ]"
-          ng-if="analyticUnit.selected && !analyticUnit.saving"
+          ng-if="
+            (analyticUnit.detectorType === 'pattern' ||
+            (analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality)) &&
+            analyticUnit.selected &&
+            !analyticUnit.saving
+          "
           ng-disabled="analyticUnit.status === 'LEARNING'"
         />
 

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -135,16 +135,16 @@
         <input
           ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
           type="text" class="gf-form-input max-width-5"
-          ng-model="analyticUnit.seasonalitySpanValue"
+          ng-model="analyticUnit.seasonalityPeriod.value"
           ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
         >
 
         <div class="gf-form-select-wrapper"
           ng-if="analyticUnit.detectorType === 'anomaly' && analyticUnit.hasSeasonality"
         >
-          <!-- TODO: move timespans from ng-options -->
+          <!-- TODO: move periods from ng-options -->
           <select class="gf-form-input width-8"
-            ng-model="analyticUnit.seasonalitySpanUnit"
+            ng-model="analyticUnit.seasonalityPeriod.unit"
             ng-change="ctrl.onSeasonalityChange(analyticUnit.id)"
             ng-options="type for type in ['seconds', 'minutes', 'days', 'hours', 'days', 'years']"
           />


### PR DESCRIPTION
Closes #281 
Closes #293 

## Changes
- `seasonality` in `AnomalyAnalyticUnit`
- labeling for `AnomalyAnalyticUnit`
- UI improvements: 
  - there is a row with detector-specific options for each analytic unit
  - each block is wrapped in `gf-form`:
    - no `ng-if` duplication 
    - better look
  - "Redetect all analytic units" button is shown only if there is at least 1 analytic unit (#293)

### Seasonality config
Imagine you created an anomaly analytic unit for a metric with seasonality where each period has a part outside the confidence interval:
![image](https://user-images.githubusercontent.com/1989898/57686161-c1547400-7641-11e9-81f7-d946019ecd8c.png)

### Labeling
Now you can set the season period and label segment you don't want to be detected
Hastic-server will shift the smoothed data by segment data so this "anomaly" will be inside the confidence interval every 20 minutes
![image](https://user-images.githubusercontent.com/1989898/57686177-cdd8cc80-7641-11e9-8c9b-f63867c6431a.png)

### UI improvements
Anomaly analytic unit settings required a lot of space, it affected UI a lot:
![image](https://user-images.githubusercontent.com/1989898/57713926-13b28680-767c-11e9-93f4-1fb414378de1.png)
