### PR TITLE
Seasonality checkbox is disabled on clearing seasonality period input #304

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -696,8 +696,11 @@ export class AnalyticController {
       .forEach(unit => unit.inspect = false);
   }
 
-  public async updateSeasonality(id: AnalyticUnitId) {
+  public async updateSeasonality(id: AnalyticUnitId, value?: number) {
     const analyticUnit = this._analyticUnitsSet.byId(id) as AnomalyAnalyticUnit;
+    if(value !== undefined) {
+      analyticUnit.seasonalityPeriod.value = value;
+    }
     await this.saveAnalyticUnit(analyticUnit);
   }
 

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -682,8 +682,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
   }
 
-  onSeasonalityChange(id: AnalyticUnitId) {
-    this.analyticsController.updateSeasonality(id);
+  onSeasonalityChange(id: AnalyticUnitId, value?: number) {
+    this.analyticsController.updateSeasonality(id, value);
     this.refresh();
   }
 

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -253,8 +253,9 @@
           <label class="gf-form-label width-9"> Seasonality Period </label>
           <input
             type="number" class="gf-form-input width-5"
-            ng-model="analyticUnit.seasonalityPeriod.value"
-            ng-blur="ctrl.onSeasonalityChange(analyticUnit.id)"
+            ng-init="seasonalityValue = analyticUnit.seasonalityPeriod.value"
+            ng-model="seasonalityValue"
+            ng-blur="ctrl.onSeasonalityChange(analyticUnit.id, seasonalityValue)"
             min="0"
           >
         </div>


### PR DESCRIPTION
Fixes #304 

## Problem
`Seasonality` checkbox becomes disabled when you remove a value from `Seasonality Period` input

## Changes
- Use temporary variable in `ng-model` instead of direct `seasonalityPeriod.value`