### PR TITLE
Anomaly analytic unit: fetch confidence bounds from server #306

### DIFF
--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -12,7 +12,7 @@ import { appEvents } from 'grafana/app/core/core';
 
 import * as _ from 'lodash';
 
-type TableTimeSeries = {
+export type TableTimeSeries = {
   values: [number, number][];
   columns: string[];
 };
@@ -206,7 +206,8 @@ export class AnalyticService {
 
   async getHSR(analyticUnitId: AnalyticUnitId, from: number, to: number): Promise<{
     hsr: TableTimeSeries,
-    smoothed?: TableTimeSeries
+    lowerBound?: TableTimeSeries,
+    upperBound?: TableTimeSeries
   } | null> {
     const data = await this.get('/query', { analyticUnitId, from, to });
     if(data === undefined) {

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -12,6 +12,7 @@ import { appEvents } from 'grafana/app/core/core';
 
 import * as _ from 'lodash';
 
+// TODO: TableTimeSeries is bad name
 export type TableTimeSeries = {
   values: [number, number][];
   columns: string[];


### PR DESCRIPTION
Fixes #306 

Should be merged together with server-side PR

## Changes
- fetch `lowerBound` and `upperBound` instead of `smoothed`

## Problem
Now confidence bounds are shown as (`smoothedData - confidence`, `smoothedData + confidence`). It's not correct when using labeling
Only analytics knows exact bounds, we should query it
