### PR TITLE
DETECTION and SUCCESS statuses

### DIFF
--- a/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
+++ b/src/panel/graph_panel/models/analytic_units/analytic_unit.ts
@@ -157,8 +157,10 @@ export class AnalyticUnit {
       value !== '404' &&
       value !== 'READY' &&
       value !== 'LEARNING' &&
+      value !== 'DETECTION' &&
       value !== 'PENDING' &&
       value !== 'FAILED' &&
+      value !== 'SUCCESS' &&
       value !== null
     ) {
       throw new Error('Unsupported status value: ' + value);

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -150,7 +150,9 @@
         <div class="gf-form">
           <label>
             <i ng-if="analyticUnit.status === 'READY'" class="grafana-tip fa fa-check-circle ng-scope" bs-tooltip="'Ready'"></i>
+            <i ng-if="analyticUnit.status === 'SUCCESS'" class="grafana-tip fa fa-check ng-scope" bs-tooltip="'Learning succeeded'"></i>
             <i ng-if="analyticUnit.status === 'LEARNING'" class="grafana-tip fa fa-leanpub ng-scope" bs-tooltip="'Learning'"></i>
+            <i ng-if="analyticUnit.status === 'DETECTION'" class="grafana-tip fa fa-search ng-scope" bs-tooltip="'Detection'"></i>
             <i ng-if="analyticUnit.status === 'PENDING'" class="grafana-tip fa fa-list-ul ng-scope" bs-tooltip="'Pending'"></i>
             <i ng-if="analyticUnit.status === 'FAILED'" class="grafana-tip fa fa-exclamation-circle ng-scope" bs-tooltip="'Error: ' + analyticUnit.error"></i>
           </label>


### PR DESCRIPTION
Fixes https://github.com/hastic/hastic-server/issues/665

## Problem
We didn't have separate status for successful learning. Only for successful detection (`READY`)
Thus, it seemed like learning is never finished for anomaly analytic unit

## Changes
- `SUCCESS` status (set when learning ended)
![image](https://user-images.githubusercontent.com/1989898/58023104-a25d5280-7b17-11e9-86ad-2590529a2d77.png)
- `DETECTION` status (set while detection process)
![image](https://user-images.githubusercontent.com/1989898/58023068-940f3680-7b17-11e9-842d-2d4176382129.png)
