### PR TITLE
Grafana 6: this._newAnalyticUnit is undefined #324

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -597,8 +597,7 @@ class GraphCtrl extends MetricsPanelCtrl {
         ]
       );
     }
-    this.$scope.$digest();
-    this.render(this.seriesList);
+    this.refresh();
   }
 
   async onAnalyticUnitAlertChange(analyticUnit: AnalyticUnit) {


### PR DESCRIPTION
Fixes #324 

## Problem
Editor state wasn't updated even after `$scope.$digest()`

## Changes
- use `refresh()` instead of `$scope.$digest()`