### PR TITLE
Show "Browser access type is not supported" message #345

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -172,7 +172,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     } else {
       throw new Error('Cannot parse grafana url');
     }
-    console.log(this)
 
     this._panelId = `${this.dashboard.uid}/${this.panel.id}`;
     this._datasources = {};
@@ -278,7 +277,6 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;
-      console.log(data.config)
 
       this._datasourceRequest = {
         url: requestConfig.url,
@@ -364,8 +362,6 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     this.dataList = dataList;
     this.loading = true;
-
-    console.log(dataList)
     let seriesList = this.processor.getSeriesList({
       dataList: this.dataList,
       range: this.range,

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -362,11 +362,11 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     this.dataList = dataList;
     this.loading = true;
+
     let seriesList = this.processor.getSeriesList({
       dataList: this.dataList,
       range: this.range,
     });
-
 
     this.dataWarning = null;
     const hasSomePoint = seriesList.some(s => s.datapoints.length > 0);
@@ -646,7 +646,7 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   async onAnalyticUnitSave(analyticUnit: AnalyticUnit) {
     if(
-      this.analyticsController.labelingUnit !== null && 
+      this.analyticsController.labelingUnit !== null &&
       this.analyticsController.labelingUnit.id === analyticUnit.id
     ) {
       await this.onToggleLabelingMode(analyticUnit.id)

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -172,6 +172,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     } else {
       throw new Error('Cannot parse grafana url');
     }
+    console.log(this)
 
     this._panelId = `${this.dashboard.uid}/${this.panel.id}`;
     this._datasources = {};
@@ -277,6 +278,7 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     appEvents.on('ds-request-response', data => {
       let requestConfig = data.config;
+      console.log(data.config)
 
       this._datasourceRequest = {
         url: requestConfig.url,
@@ -362,11 +364,13 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     this.dataList = dataList;
     this.loading = true;
-    
+
+    console.log(dataList)
     let seriesList = this.processor.getSeriesList({
       dataList: this.dataList,
       range: this.range,
     });
+
 
     this.dataWarning = null;
     const hasSomePoint = seriesList.some(s => s.datapoints.length > 0);
@@ -758,6 +762,9 @@ class GraphCtrl extends MetricsPanelCtrl {
   private async _getDatasourceRequest() {
     if(this._datasourceRequest.type === undefined) {
       const datasource = await this._getDatasourceByName(this.panel.datasource);
+      if(datasource.access !== 'proxy') {
+        throw new Error(`"${datasource.name}" datasource has Browser access type but only Server is supported`);
+      }
       this._datasourceRequest.type = datasource.type;
     }
     return this._datasourceRequest;

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -763,7 +763,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     if(this._datasourceRequest.type === undefined) {
       const datasource = await this._getDatasourceByName(this.panel.datasource);
       if(datasource.access !== 'proxy') {
-        throw new Error(`"${datasource.name}" datasource has Browser access type but only Server is supported`);
+        throw new Error(`"${datasource.name}" datasource has "Browser" access type but only "Server" is supported`);
       }
       this._datasourceRequest.type = datasource.type;
     }


### PR DESCRIPTION
Closes #345 

## Changes
- this message is shown when trying to create analytic unit for a metric with access type `Browser`
![image](https://user-images.githubusercontent.com/1989898/59515667-4bedf480-8ec8-11e9-8160-47acd58550e6.png)

