### PR TITLE
Disable alerts for webhook images rendering

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -168,6 +168,11 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     const grafanaUrlRegex = /^(.+)\/d/;
     const parsedUrl = window.location.href.match(grafanaUrlRegex);
+    // api-rendering parameter is added for webhook images rendering
+    // We disable alerts in this case
+    if(window.location.search.includes('api-rendering')) {
+      appEvents.emit = function() { };
+    }
     if(parsedUrl !== null) {
       this._grafanaUrl = parsedUrl[1];
     } else {


### PR DESCRIPTION
## Problem
There is alert when panel is rendered using Grafana API
![image](https://user-images.githubusercontent.com/1989898/60531287-4fc0aa00-9d03-11e9-91da-0a5837c6d938.png)

## Changes
- `api-rendering` URL flag which disables alerts

## Usage example
http://localhost:3000/render/d-solo/bGQH0umZz/hastic?panelId=2&orgId=1&api-rendering