### PR TITLE
Error: can't read property 'type' of undefined #353

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -763,7 +763,7 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   private async _getDatasourceRequest() {
     if(this._datasourceRequest === undefined) {
-      throw new Error('Grafana test-datasource is not supported')
+      throw new Error('Datasource is not set. If it`s Grafana test-datasource - it`s not supported');
     }
     if(this._datasourceRequest.type === undefined) {
       const datasource = await this._getDatasourceByName(this.panel.datasource);

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -762,6 +762,9 @@ class GraphCtrl extends MetricsPanelCtrl {
   }
 
   private async _getDatasourceRequest() {
+    if(this._datasourceRequest === undefined) {
+      throw new Error('Grafana test-datasource is not supported')
+    }
     if(this._datasourceRequest.type === undefined) {
       const datasource = await this._getDatasourceByName(this.panel.datasource);
       if(datasource.access !== 'proxy') {


### PR DESCRIPTION
Grafana test-datasource doesn't query backend. Thus, we don't get `ds-request-response` event and `this._datasourceRequest` stays `undefined`.

## Changes
- throw `Grafana test-datasource is not supported` if there was no request to datasource (`this._datasourceRequest === undefined` )

![image](https://user-images.githubusercontent.com/1989898/61777033-e6652000-ae04-11e9-8162-4865b31f41ae.png)
