### PR TITLE
Handle HTTP 504 error #366

### DIFF
--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -251,9 +251,10 @@ export class AnalyticService {
     } catch(error) {
       // xhrStatus may be one of: ('complete', 'error', 'timeout' or 'abort')
       // See: https://github.com/angular/angular.js/blob/55075b840c9194b8524627a293d6166528b9a1c2/src/ng/http.js#L919-L920
-      if(error.xhrStatus !== 'complete' || error.status === 502) {
+      if(error.xhrStatus !== 'complete' || error.status > 500) {
         this.displayConnectionErrorAlert();
         this._isUp = false;
+        throw new Error(`Fetching error: ${error.status}: ${error.statusText}`);
       } else {
         this._isUp = true;
       }


### PR DESCRIPTION
Fixes #366 

Only 502 error was handled

## Changes
- handle all errors with error code > 500. 500 is Hastic-server's error code
- throw new error to prevent `undefined` request result