### PR TITLE
update the 504(timeout) error message

### DIFF
--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -299,7 +299,7 @@ export class AnalyticService {
     appEvents.emit(
       'alert-error',
       [
-        'No connection to Hastic Server',
+        'Timeout when connecting to Hastic Server',
         `Hastic Datasource URL: "${this._hasticDatasourceURL}"`,
       ]
     );


### PR DESCRIPTION
Changed `No connection to Hastic Server` message when 504 (timeout) error occurs to `Timeout when connecting to Hastic Server`.

closes #370