### PR TITLE
Change segments icons in tooltip #376

### DIFF
--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -208,7 +208,7 @@ export class GraphTooltip {
       if(s.segment.labeled) {
         icon = 'fa-thumb-tack';
       } else if (s.segment.deleted) {
-        icon = 'fa-trash';
+        icon = 'fa-search-minus';
       } else {
         icon = 'fa-search-plus';
       }

--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -108,6 +108,7 @@ export class GraphTooltip {
         series = seriesList[hoverInfo.index];
 
         value = series.formatValue(hoverInfo.value);
+
         seriesHtml += '<div class="graph-tooltip-list-item ' + highlightClass + '"><div class="graph-tooltip-series-name">';
         seriesHtml += '<i class="fa fa-minus" style="color:' + hoverInfo.color +';"></i> ' + hoverInfo.label + ':</div>';
         seriesHtml += '<div class="graph-tooltip-value">' + value + '</div></div>';

--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -213,7 +213,7 @@ export class GraphTooltip {
         icon = 'fa-search-plus';
       }
       let segmentColor = s.analyticUnit.labeledColor;
-      if(s.analyticUnit.detectorType === 'pattern' && s.segment.deleted === true) {
+      if(s.segment.deleted === true) {
         segmentColor = s.analyticUnit.deletedColor;
       }
       result += `

--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -219,11 +219,10 @@ export class GraphTooltip {
       result += `
         <div class="graph-tooltip-list-item">
           <div class="graph-tooltip-series-name">
-            <i class="fa fa-exclamation" style="color:${segmentColor}"></i>
+            <i class="fa ${ icon }" style="color:${segmentColor}"></i>
             ${s.analyticUnit.name}:
           </div>
           <div class="graph-tooltip-value">
-            <i class="fa ${ icon }" aria-hidden="true"></i>
             ${from} — ${to}
           </div>
         </div>

--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -206,12 +206,16 @@ export class GraphTooltip {
       var to = this.dashboard.formatDate(s.segment.to, 'HH:mm:ss.SSS');
 
       let icon;
+      let subIcon;
       if(s.segment.labeled) {
         icon = 'fa-thumb-tack';
+        subIcon = 'fa-plus';
       } else if (s.segment.deleted) {
-        icon = 'fa-search-minus';
+        icon = 'fa-thumb-tack';
+        subIcon = 'fa-minus';
       } else {
-        icon = 'fa-search-plus';
+        icon = 'fa-check-circle';
+        subIcon = '';
       }
       let segmentColor = s.analyticUnit.labeledColor;
       if(s.segment.deleted === true) {
@@ -221,6 +225,7 @@ export class GraphTooltip {
         <div class="graph-tooltip-list-item">
           <div class="graph-tooltip-series-name">
             <i class="fa ${ icon }" style="color:${segmentColor}"></i>
+            <i class="fa ${ subIcon }" style="color:${segmentColor}"></i>
             ${s.analyticUnit.name}:
           </div>
           <div class="graph-tooltip-value">

--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -108,7 +108,6 @@ export class GraphTooltip {
         series = seriesList[hoverInfo.index];
 
         value = series.formatValue(hoverInfo.value);
-
         seriesHtml += '<div class="graph-tooltip-list-item ' + highlightClass + '"><div class="graph-tooltip-series-name">';
         seriesHtml += '<i class="fa fa-minus" style="color:' + hoverInfo.color +';"></i> ' + hoverInfo.label + ':</div>';
         seriesHtml += '<div class="graph-tooltip-value">' + value + '</div></div>';
@@ -213,10 +212,14 @@ export class GraphTooltip {
       } else {
         icon = 'fa-search-plus';
       }
+      let segmentColor = s.analyticUnit.labeledColor;
+      if(s.analyticUnit.detectorType === 'pattern' && s.segment.deleted === true) {
+        segmentColor = s.analyticUnit.deletedColor;
+      }
       result += `
         <div class="graph-tooltip-list-item">
           <div class="graph-tooltip-series-name">
-            <i class="fa fa-exclamation" style="color:${s.analyticUnit.labeledColor}"></i>
+            <i class="fa fa-exclamation" style="color:${segmentColor}"></i>
             ${s.analyticUnit.name}:
           </div>
           <div class="graph-tooltip-value">

--- a/src/panel/graph_panel/graph_tooltip.ts
+++ b/src/panel/graph_panel/graph_tooltip.ts
@@ -214,7 +214,7 @@ export class GraphTooltip {
         icon = 'fa-thumb-tack';
         subIcon = 'fa-minus';
       } else {
-        icon = 'fa-check-circle';
+        icon = 'fa-crosshairs';
         subIcon = '';
       }
       let segmentColor = s.analyticUnit.labeledColor;


### PR DESCRIPTION
Closes #376 

Improve UI

## Changes:

- make icon color the same as segment color
- remove `fa-exclamation` icon and replace right icon from date to analytic unit name
- change icon for positive labeled, negative labeled, found segments

## Before:

positive labeled:
![image](https://user-images.githubusercontent.com/39257464/66304398-bad2db80-e905-11e9-84ae-8cd99bf1be6c.png)

negative labeled:
![image](https://user-images.githubusercontent.com/39257464/66304442-d63de680-e905-11e9-90ba-cbc00f8fd213.png)

found segments:
![image](https://user-images.githubusercontent.com/39257464/66304511-05ecee80-e906-11e9-9c06-653c5a2528b3.png)



## After:

positive labeled:
![image](https://user-images.githubusercontent.com/39257464/63850195-34d58380-c99c-11e9-9abe-33cfa756bdb9.png)

negative labeled:
![image](https://user-images.githubusercontent.com/39257464/63850234-474fbd00-c99c-11e9-9e04-00f79aba32c2.png)

found segments:
![image](https://user-images.githubusercontent.com/39257464/64192450-61e5d280-ce83-11e9-8adf-2abde79ca741.png)

