### PR TITLE
Panels are not rendered without a refresh sometimes #223

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -433,9 +433,15 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     if(this.analyticsController === undefined || !this.analyticsController.graphLocked) {
-      this._graphRenderer.render(this.seriesList);
-      this._graphLegend.render();
-      this._graphRenderer.renderPanel();
+      if(this._graphRenderer !== undefined && this.seriesList !== undefined) {
+        this._graphRenderer.render(this.seriesList);
+      }
+      if(this._graphLegend !== undefined) {
+        this._graphLegend.render();
+      }
+      if(this._graphRenderer !== undefined) {
+        this._graphRenderer.renderPanel();
+      }
     }
   }
 

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -324,6 +324,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.$graphElem, this.timeSrv, this.contextSrv, this.$scope, this.analyticsController
     );
     this._graphLegend = new GraphLegend(this.$legendElem, this.popoverSrv, this.$scope, this.analyticsController);
+    this.onRender();
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -422,7 +422,7 @@ class GraphCtrl extends MetricsPanelCtrl {
   }
 
   onRender() {
-    if(!this.seriesList) {
+    if(!this.seriesList || !this._graphRenderer || !this._graphLegend) {
       return;
     }
 
@@ -433,15 +433,9 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     if(this.analyticsController === undefined || !this.analyticsController.graphLocked) {
-      if(this._graphRenderer !== undefined && this.seriesList !== undefined) {
-        this._graphRenderer.render(this.seriesList);
-      }
-      if(this._graphLegend !== undefined) {
-        this._graphLegend.render();
-      }
-      if(this._graphRenderer !== undefined) {
-        this._graphRenderer.renderPanel();
-      }
+      this._graphRenderer.render(this.seriesList);
+      this._graphLegend.render();
+      this._graphRenderer.renderPanel();
     }
   }
 


### PR DESCRIPTION
Closes #223 

We don't await `this.onHasticDatasourceChange()`, so `_graphRenderer` or `_graphLegend` can be `undefined`.

## Changes:

- add check for `undefined` before render.