### PR TITLE
Error while saving analytic unit: this._datasourceRequest is undefined #207

### DIFF
--- a/src/panel/graph_panel/models/metric.ts
+++ b/src/panel/graph_panel/models/metric.ts
@@ -29,7 +29,7 @@ export class MetricExpanded {
   constructor(public datasource: string, targets: any[]) {
     const visibleTargets = targets.filter(target => !target.hide);
     if(visibleTargets.length === 0) {
-      throw new Error('There are no metrics. Please add at least 1 metric');
+      throw new Error('There are no visible metrics. Please add at least 1 metric');
     }
     if(visibleTargets.length > 1) {
       throw new Error('Multiple metrics are not supported currently');

--- a/src/panel/graph_panel/models/metric.ts
+++ b/src/panel/graph_panel/models/metric.ts
@@ -29,7 +29,7 @@ export class MetricExpanded {
   constructor(public datasource: string, targets: any[]) {
     const visibleTargets = targets.filter(target => !target.hide);
     if(visibleTargets.length === 0) {
-      throw new Error('There are no visible metrics. Please add at least 1 metric');
+      throw new Error('There are no visible metrics. Please add at least one metric');
     }
     if(visibleTargets.length > 1) {
       throw new Error('Multiple metrics are not supported currently');

--- a/src/panel/graph_panel/models/metric.ts
+++ b/src/panel/graph_panel/models/metric.ts
@@ -28,6 +28,9 @@ export class MetricExpanded {
   private _targets: Target[];
   constructor(public datasource: string, targets: any[]) {
     const visibleTargets = targets.filter(target => !target.hide);
+    if(visibleTargets.length === 0) {
+      throw new Error('There are no metrics. Please add at least 1 metric');
+    }
     if(visibleTargets.length > 1) {
       throw new Error('Multiple metrics are not supported currently');
     }


### PR DESCRIPTION
Closes #207 

If there is no visible metric, `Error while saving analytic unit: Cannot read property 'id' of undefined` alert will be displayed.

## Changes:
 - Add check in `MetricExpanded` constructor. If there is no visible mertic, `Error while saving analytic unit:  There are no visible metrics. Please add at least one metric` alert will be displayed.

### Before:

![photo_2019-10-23_16-47-52](https://user-images.githubusercontent.com/39257464/67399420-e7008480-f5b4-11e9-9d11-2f22d53b8b2d.jpg)

### After:

![image](https://user-images.githubusercontent.com/39257464/67407754-a9095d80-f5c0-11e9-8607-725093ba28ab.png)
