### PR TITLE
Images in webhooks don't have detections #387

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -67,7 +67,10 @@ export class AnalyticController {
     this._labelingDataAddedSegments = new SegmentArray<AnalyticSegment>();
     this._labelingDataRemovedSegments = new SegmentArray<AnalyticSegment>();
     this._analyticUnitsSet = new AnalyticUnitsSet([]);
-    this.fetchAnalyticUnits();
+  }
+
+  async init() {
+    await this.fetchAnalyticUnits();
   }
 
   get helpSectionText() { return helpSectionText; }

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -62,7 +62,7 @@ export class AnalyticController {
     private _panelObject: any,
     private _emitter: Emitter,
     private _analyticService?: AnalyticService,
-    private _webhookId?: string,    
+    private _analyticUnitsToShow?: AnalyticUnitId | AnalyticUnitId[],
   ) {
     this._labelingDataAddedSegments = new SegmentArray<AnalyticSegment>();
     this._labelingDataRemovedSegments = new SegmentArray<AnalyticSegment>();
@@ -243,12 +243,20 @@ export class AnalyticController {
     });
   }
 
-  showOnlyWebhookAnalyticUnit() {
-    if(this._webhookId === undefined) {
-      return ;
+  private _showOnlySpecifiedAnalyticUnits() {
+    if(this._analyticUnitsToShow === undefined) {
+      return;
     }
+
+    if(!_.isArray(this._analyticUnitsToShow)) {
+      this._analyticUnitsToShow = [this._analyticUnitsToShow];
+    }
+
     this.analyticUnits.forEach(analyticUnit => {
-      if(analyticUnit.id !== this._webhookId) {
+      const shouldShow = _.includes(this._analyticUnitsToShow, analyticUnit.id);
+      if(shouldShow) {
+        analyticUnit.visible = true;
+      } else {
         analyticUnit.visible = false;
       }
     });
@@ -357,7 +365,7 @@ export class AnalyticController {
       options.grid.markings = [];
     }
 
-    this.showOnlyWebhookAnalyticUnit();
+    this._showOnlySpecifiedAnalyticUnits();
     for(let i = 0; i < this.analyticUnits.length; i++) {
       const analyticUnit = this.analyticUnits[i];
       if(!analyticUnit.visible) {

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -31,6 +31,7 @@ import {
 } from '../colors';
 
 import { Emitter } from 'grafana/app/core/utils/emitter';
+import { appEvents } from 'grafana/app/core/core';
 
 import _ from 'lodash';
 import * as tinycolor from 'tinycolor2';
@@ -511,6 +512,13 @@ export class AnalyticController {
   }
 
   async fetchAnalyticUnits(): Promise<void> {
+    appEvents.emit(
+      'alert-success',
+      [
+        `fetchAnalyticUnits`,
+        ''
+      ]
+    );
     const units = await this.getAnalyticUnits();
     this._analyticUnitsSet = new AnalyticUnitsSet(units);
     this._loading = false;

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -339,7 +339,7 @@ export class AnalyticController {
   }
 
   // TODO: move to renderer
-  updateFlotEvents(isEditMode: boolean, plot: any): void {
+  updateFlotEvents(isEditMode: boolean, plot: any, webId?: string ): void {
     // We get a reference to flot options so we can change it and it'll be rendered
     let options = plot.getOptions();
     if(options.grid.markings === undefined) {
@@ -348,7 +348,7 @@ export class AnalyticController {
 
     for(let i = 0; i < this.analyticUnits.length; i++) {
       const analyticUnit = this.analyticUnits[i];
-      if(!analyticUnit.visible) {
+      if(!analyticUnit.visible || analyticUnit.id !== webId) {
         continue;
       }
 
@@ -512,13 +512,6 @@ export class AnalyticController {
   }
 
   async fetchAnalyticUnits(): Promise<void> {
-    appEvents.emit(
-      'alert-success',
-      [
-        `fetchAnalyticUnits`,
-        ''
-      ]
-    );
     const units = await this.getAnalyticUnits();
     this._analyticUnitsSet = new AnalyticUnitsSet(units);
     this._loading = false;

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -63,6 +63,7 @@ export class AnalyticController {
     private _panelObject: any,
     private _emitter: Emitter,
     private _analyticService?: AnalyticService,
+    private _webhookId?: string,    
   ) {
     this._labelingDataAddedSegments = new SegmentArray<AnalyticSegment>();
     this._labelingDataRemovedSegments = new SegmentArray<AnalyticSegment>();
@@ -243,6 +244,16 @@ export class AnalyticController {
     });
   }
 
+  hideAnalyticUnitsExeptOne() {
+    if(this._webhookId !== undefined) {
+      this.analyticUnits.forEach(analyticUnit => {
+        if (analyticUnit.id !== this._webhookId) {
+          analyticUnit.visible = false;
+        }
+      });
+    }
+  }
+
   stopAnalyticUnitsDetectionsFetching() {
     this.analyticUnits.forEach(analyticUnit => this._detectionRunners.delete(analyticUnit.id));
   }
@@ -339,16 +350,17 @@ export class AnalyticController {
   }
 
   // TODO: move to renderer
-  updateFlotEvents(isEditMode: boolean, plot: any, webId?: string ): void {
+  updateFlotEvents(isEditMode: boolean, plot: any): void {
     // We get a reference to flot options so we can change it and it'll be rendered
     let options = plot.getOptions();
     if(options.grid.markings === undefined) {
       options.grid.markings = [];
     }
 
+    this.hideAnalyticUnitsExeptOne();
     for(let i = 0; i < this.analyticUnits.length; i++) {
       const analyticUnit = this.analyticUnits[i];
-      if(!analyticUnit.visible || analyticUnit.id !== webId) {
+      if(!analyticUnit.visible) {
         continue;
       }
 

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -31,7 +31,6 @@ import {
 } from '../colors';
 
 import { Emitter } from 'grafana/app/core/utils/emitter';
-import { appEvents } from 'grafana/app/core/core';
 
 import _ from 'lodash';
 import * as tinycolor from 'tinycolor2';
@@ -244,14 +243,15 @@ export class AnalyticController {
     });
   }
 
-  hideAnalyticUnitsExeptOne() {
-    if(this._webhookId !== undefined) {
-      this.analyticUnits.forEach(analyticUnit => {
-        if (analyticUnit.id !== this._webhookId) {
-          analyticUnit.visible = false;
-        }
-      });
+  showOnlyWebhookAnalyticUnit() {
+    if(this._webhookId === undefined) {
+      return ;
     }
+    this.analyticUnits.forEach(analyticUnit => {
+      if(analyticUnit.id !== this._webhookId) {
+        analyticUnit.visible = false;
+      }
+    });
   }
 
   stopAnalyticUnitsDetectionsFetching() {
@@ -357,7 +357,7 @@ export class AnalyticController {
       options.grid.markings = [];
     }
 
-    this.hideAnalyticUnitsExeptOne();
+    this.showOnlyWebhookAnalyticUnit();
     for(let i = 0; i < this.analyticUnits.length; i++) {
       const analyticUnit = this.analyticUnits[i];
       if(!analyticUnit.visible) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -58,7 +58,7 @@ class GraphCtrl extends MetricsPanelCtrl {
   private _grafanaUrl: string;
   private _panelId: string;
 
-  private _showAnalyticUnitIds: AnalyticUnitId | AnalyticUnitId[];
+  private _analyticUnitsToShow: AnalyticUnitId | AnalyticUnitId[];
 
   private _dataTimerange: {
     from?: number,
@@ -176,7 +176,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     if(params.apiRendering !== undefined) {
       appEvents.emit = function() { };
     }
-    this._showAnalyticUnitIds = params.showAnalyticUnit;
+    this._analyticUnitsToShow = params.analyticUnitId;
 
     if(parsedUrl !== null) {
       this._grafanaUrl = parsedUrl[1];
@@ -327,7 +327,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.panel,
       this.events,
       this.analyticService,
-      this._showAnalyticUnitIds
+      this._analyticUnitsToShow
     );
 
     this._updatePanelInfo();

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -250,7 +250,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.$graphElem = $(elem[0]).find('#graphPanel');
     this.$legendElem = $(elem[0]).find('#graphLegend');
 
-    this.onHasticDatasourceChange();
+    await this.onHasticDatasourceChange();
 
     this.events.on('render', this.onRender.bind(this));
     this.events.on('data-received', this.onDataReceived.bind(this));
@@ -330,6 +330,8 @@ class GraphCtrl extends MetricsPanelCtrl {
       this._analyticUnitsToShow
     );
 
+    await this.analyticsController.init();
+
     this._updatePanelInfo();
     this.analyticsController.updateServerInfo();
 
@@ -337,7 +339,6 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.$graphElem, this.timeSrv, this.contextSrv, this.$scope, this.analyticsController
     );
     this._graphLegend = new GraphLegend(this.$legendElem, this.popoverSrv, this.$scope, this.analyticsController);
-    this.onRender();
   }
 
   issueQueries(datasource) {
@@ -429,6 +430,7 @@ class GraphCtrl extends MetricsPanelCtrl {
         this._dataTimerange.to
       );
     }
+
     this.seriesList = seriesList;
     this.render();
 

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -330,7 +330,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.$graphElem, this.timeSrv, this.contextSrv, this.$scope, this.analyticsController
     );
     this._graphLegend = new GraphLegend(this.$legendElem, this.popoverSrv, this.$scope, this.analyticsController);
-    // this.onRender();
+    this.onRender();
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -284,6 +284,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       }
     });
 
+    // TODO: maybe it's not the best idea
     await this.onHasticDatasourceChange();
   }
 

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -330,10 +330,14 @@ class GraphCtrl extends MetricsPanelCtrl {
       this._analyticUnitsToShow
     );
 
-    await this.analyticsController.init();
+    if(this.analyticService.isUp) {
+      await this.analyticsController.init();
 
-    this._updatePanelInfo();
-    this.analyticsController.updateServerInfo();
+      this._updatePanelInfo();
+      this.analyticsController.updateServerInfo();
+    } else {
+      this.refresh()
+    }
 
     this._graphRenderer = new GraphRenderer(
       this.$graphElem, this.timeSrv, this.contextSrv, this.$scope, this.analyticsController

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -321,7 +321,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       }
     }
 
-    this.analyticsController = new AnalyticController(this._grafanaUrl, this._panelId, this.panel, this.events, this.analyticService);
+    this.analyticsController = new AnalyticController(this._grafanaUrl, this._panelId, this.panel, this.events, this.analyticService, this._webhookId);
 
     this._updatePanelInfo();
     this.analyticsController.updateServerInfo();
@@ -440,7 +440,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     if(this.analyticsController === undefined || !this.analyticsController.graphLocked) {
-      this._graphRenderer.render(this.seriesList, this._webhookId);
+      this._graphRenderer.render(this.seriesList);
       this._graphLegend.render();
       this._graphRenderer.renderPanel();
     }

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -250,8 +250,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.$graphElem = $(elem[0]).find('#graphPanel');
     this.$legendElem = $(elem[0]).find('#graphLegend');
 
-    await this.onHasticDatasourceChange();
-
     this.events.on('render', this.onRender.bind(this));
     this.events.on('data-received', this.onDataReceived.bind(this));
     this.events.on('data-error', this.onDataError.bind(this));
@@ -285,6 +283,8 @@ class GraphCtrl extends MetricsPanelCtrl {
         this.refresh();
       }
     });
+
+    await this.onHasticDatasourceChange();
   }
 
   onInitEditMode() {
@@ -335,14 +335,16 @@ class GraphCtrl extends MetricsPanelCtrl {
 
       this._updatePanelInfo();
       this.analyticsController.updateServerInfo();
-    } else {
-      this.refresh()
     }
 
     this._graphRenderer = new GraphRenderer(
       this.$graphElem, this.timeSrv, this.contextSrv, this.$scope, this.analyticsController
     );
     this._graphLegend = new GraphLegend(this.$legendElem, this.popoverSrv, this.$scope, this.analyticsController);
+
+    if(!this.analyticService.isUp) {
+      this.refresh();
+    }
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -324,7 +324,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.$graphElem, this.timeSrv, this.contextSrv, this.$scope, this.analyticsController
     );
     this._graphLegend = new GraphLegend(this.$legendElem, this.popoverSrv, this.$scope, this.analyticsController);
-    this.onRender();
+    // this.onRender();
   }
 
   issueQueries(datasource) {
@@ -438,6 +438,13 @@ class GraphCtrl extends MetricsPanelCtrl {
       this._graphLegend.render();
       this._graphRenderer.renderPanel();
     }
+    appEvents.emit(
+      'alert-success',
+      [
+        `onRender`,
+        ``
+      ]
+    );
   }
 
   changeSeriesColor(series, color) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -22,8 +22,8 @@ import _ from 'lodash';
 
 
 enum PanelParameter {
-  API_RENDERING = 'api-rendering',
-  SHOW_ANALYTIC_UNIT = 'show-analytic-unit'
+  API_RENDERING = 'apiRendering',
+  SHOW_ANALYTIC_UNIT = 'showAnalyticUnit'
 };
 
 class GraphCtrl extends MetricsPanelCtrl {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -58,6 +58,8 @@ class GraphCtrl extends MetricsPanelCtrl {
   private _grafanaUrl: string;
   private _panelId: string;
 
+  private _webhookId: string = undefined;
+
   private _dataTimerange: {
     from?: number,
     to?: number
@@ -171,6 +173,10 @@ class GraphCtrl extends MetricsPanelCtrl {
     // We disable alerts in this case
     if(window.location.search.includes('api-rendering')) {
       appEvents.emit = function() { };
+    }
+    if(window.location.search.includes('unitId')) {
+      const reg = /unitId=([^\&]*)&/;
+      this._webhookId = window.location.search.match(reg)[1];
     }
     if(parsedUrl !== null) {
       this._grafanaUrl = parsedUrl[1];
@@ -434,17 +440,10 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     if(this.analyticsController === undefined || !this.analyticsController.graphLocked) {
-      this._graphRenderer.render(this.seriesList);
+      this._graphRenderer.render(this.seriesList, this._webhookId);
       this._graphLegend.render();
       this._graphRenderer.renderPanel();
     }
-    appEvents.emit(
-      'alert-success',
-      [
-        `onRender`,
-        ``
-      ]
-    );
   }
 
   changeSeriesColor(series, color) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -21,11 +21,6 @@ import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 import _ from 'lodash';
 
 
-enum PanelParameter {
-  API_RENDERING = 'apiRendering',
-  SHOW_ANALYTIC_UNIT = 'showAnalyticUnit'
-};
-
 class GraphCtrl extends MetricsPanelCtrl {
   static template = template;
 
@@ -178,10 +173,10 @@ class GraphCtrl extends MetricsPanelCtrl {
     const params = this.$location.search();
     // api-rendering parameter is added for webhook images rendering
     // We disable alerts in this case
-    if(params[PanelParameter.API_RENDERING] !== undefined) {
+    if(params.apiRendering !== undefined) {
       appEvents.emit = function() { };
     }
-    this._showAnalyticUnitIds = params[PanelParameter.SHOW_ANALYTIC_UNIT];
+    this._showAnalyticUnitIds = params.showAnalyticUnit;
 
     if(parsedUrl !== null) {
       this._grafanaUrl = parsedUrl[1];
@@ -327,11 +322,11 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
 
     this.analyticsController = new AnalyticController(
-      this._grafanaUrl, 
-      this._panelId, 
-      this.panel, 
-      this.events, 
-      this.analyticService, 
+      this._grafanaUrl,
+      this._panelId,
+      this.panel,
+      this.events,
+      this.analyticService,
       this._showAnalyticUnitIds
     );
 

--- a/src/panel/graph_panel/graph_renderer.ts
+++ b/src/panel/graph_panel/graph_renderer.ts
@@ -42,6 +42,7 @@ export class GraphRenderer {
 
   ;
   private data: any;
+  private webhookId: string;
   private tooltip: GraphTooltip;
   private panelWidth: number;
   private plot: any;
@@ -205,11 +206,15 @@ export class GraphRenderer {
     }
   }
 
-  public render(renderData) {
+  public render(renderData, webhookId?) {
 
     this.data = renderData || this.data;
     if (!this.data) {
       return;
+    }
+
+    if(webhookId !== undefined) {
+      this.webhookId = webhookId;
     }
     // this.annotations = this.ctrl.annotations || [];
     this._buildFlotPairs(this.data);
@@ -335,7 +340,7 @@ export class GraphRenderer {
     this.panel.dashes = this.panel.lines ? this.panel.dashes : false;
 
     // Populate element
-    this._buildFlotOptions(this.panel);
+    this._buildFlotOptions(this.panel);//build 2 units
     this._prepareXAxis(this.panel);
     this._configureYAxisOptions(this.data);
     // this.eventManager.addFlotEvents(this.annotations, this.flotOptions);
@@ -444,7 +449,7 @@ export class GraphRenderer {
   
   private _drawAnalyticHook(plot: any) {
     // We call updateFlotEvents from hook cause we need access to min Y axis value
-    this._analyticController.updateFlotEvents(this.contextSrv.isEditor, plot)
+    this._analyticController.updateFlotEvents(this.contextSrv.isEditor, plot, this.webhookId);
   }
 
   private _buildFlotOptions(panel) {

--- a/src/panel/graph_panel/graph_renderer.ts
+++ b/src/panel/graph_panel/graph_renderer.ts
@@ -42,7 +42,6 @@ export class GraphRenderer {
 
   ;
   private data: any;
-  private webhookId: string;
   private tooltip: GraphTooltip;
   private panelWidth: number;
   private plot: any;
@@ -206,16 +205,13 @@ export class GraphRenderer {
     }
   }
 
-  public render(renderData, webhookId?) {
+  public render(renderData) {
 
     this.data = renderData || this.data;
     if (!this.data) {
       return;
     }
 
-    if(webhookId !== undefined) {
-      this.webhookId = webhookId;
-    }
     // this.annotations = this.ctrl.annotations || [];
     this._buildFlotPairs(this.data);
     updateLegendValues(this.data, this.panel);
@@ -449,7 +445,7 @@ export class GraphRenderer {
   
   private _drawAnalyticHook(plot: any) {
     // We call updateFlotEvents from hook cause we need access to min Y axis value
-    this._analyticController.updateFlotEvents(this.contextSrv.isEditor, plot, this.webhookId);
+    this._analyticController.updateFlotEvents(this.contextSrv.isEditor, plot);
   }
 
   private _buildFlotOptions(panel) {

--- a/src/panel/graph_panel/graph_renderer.ts
+++ b/src/panel/graph_panel/graph_renderer.ts
@@ -211,7 +211,6 @@ export class GraphRenderer {
     if (!this.data) {
       return;
     }
-
     // this.annotations = this.ctrl.annotations || [];
     this._buildFlotPairs(this.data);
     updateLegendValues(this.data, this.panel);
@@ -336,7 +335,7 @@ export class GraphRenderer {
     this.panel.dashes = this.panel.lines ? this.panel.dashes : false;
 
     // Populate element
-    this._buildFlotOptions(this.panel);//build 2 units
+    this._buildFlotOptions(this.panel);
     this._prepareXAxis(this.panel);
     this._configureYAxisOptions(this.data);
     // this.eventManager.addFlotEvents(this.annotations, this.flotOptions);
@@ -445,7 +444,7 @@ export class GraphRenderer {
   
   private _drawAnalyticHook(plot: any) {
     // We call updateFlotEvents from hook cause we need access to min Y axis value
-    this._analyticController.updateFlotEvents(this.contextSrv.isEditor, plot);
+    this._analyticController.updateFlotEvents(this.contextSrv.isEditor, plot)
   }
 
   private _buildFlotOptions(panel) {

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -113,6 +113,7 @@ export class AnalyticService {
 
       this._isUp = true;
     } catch(e) {
+      console.error(e);
       this.displayNoConnectionAlert();
       this._isUp = false;
     }

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -96,10 +96,10 @@ export class AnalyticService {
     return this.delete('/analyticUnits', { id });
   }
 
-  private async _isDatasourceOk(): Promise<boolean> {
+  private async _checkDatasourceAvailability(): Promise<void> {
     if(!this._checkDatasourceConfig()) {
       this._isUp = false;
-      return false;
+      return;
     }
     try {
       const response = await this.get('/');
@@ -117,7 +117,6 @@ export class AnalyticService {
       this.displayNoConnectionAlert();
       this._isUp = false;
     }
-    return this._isUp;
   }
 
   async updateSegments(
@@ -248,8 +247,8 @@ export class AnalyticService {
   }
 
   async isDatasourceAvailable(): Promise<boolean> {
-    const connected = await this._isDatasourceOk();
-    if(!connected) {
+    await this._checkDatasourceAvailability();
+    if(!this._isUp) {
       return false;
     }
     const message = [

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -101,12 +101,19 @@ export class AnalyticService {
       this._isUp = false;
       return false;
     }
-    const response = await this.get('/');
-    if(!isHasticServerResponse(response)) {
-      this.displayWrongUrlAlert();
-      this._isUp = false;
-    } else if(!isSupportedServerVersion(response)) {
-      this.displayUnsupportedVersionAlert(response.packageVersion);
+    try {
+      const response = await this.get('/');
+      if(!isHasticServerResponse(response)) {
+        this.displayWrongUrlAlert();
+        this._isUp = false;
+      } else if(!isSupportedServerVersion(response)) {
+        this.displayUnsupportedVersionAlert(response.packageVersion);
+        this._isUp = false;
+      }
+
+      this._isUp = true;
+    } catch(e) {
+      this.displayNoConnectionAlert();
       this._isUp = false;
     }
     return this._isUp;

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -58,13 +58,6 @@ export class AnalyticService {
     if(resp === undefined) {
       return [];
     }
-    appEvents.emit(
-      'alert-success',
-      [
-        `getAnalyticUnits`,
-        panelId
-      ]
-    );
     return resp.analyticUnits;
   }
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -58,6 +58,13 @@ export class AnalyticService {
     if(resp === undefined) {
       return [];
     }
+    appEvents.emit(
+      'alert-success',
+      [
+        `getAnalyticUnits`,
+        panelId
+      ]
+    );
     return resp.analyticUnits;
   }
 


### PR DESCRIPTION
Fixes #387 

There was no detections in webhook images because `render()` was called before analytic units fetching.

## Changes
- move `fetchAnalyticUnit` from constructor to a separate `init()` method to make it `await`-able
- handle exception in `_isDatasourceOk()`, it was expected to return `false`, not to throw
- use analytics in `onHasticDatasourceChange()` only if it's available