### PR TITLE
Do not disable Apply button when unit is in LEARNING state #401

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -644,14 +644,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.analyticsController.runDetect(
       analyticUnit.id,
       from, to
-    )
-
-    if(analyticUnit.changed) {
-      await this.onAnalyticUnitSave(analyticUnit);
-    }
-    this.analyticsController.runDetect(
-      analyticUnit.id,
-      from, to
     );
   }
 

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -621,25 +621,30 @@ class GraphCtrl extends MetricsPanelCtrl {
   }
 
   async runDetectInCurrentRange(analyticUnit: AnalyticUnit) {
-    const { from, to } = this.rangeTimestamp;
-
     if(analyticUnit.status === 'LEARNING' || analyticUnit.saving) {
       let modalScope = this.$scope.$new(true);
       modalScope.confirm = async () => {
-        if(analyticUnit.changed) {
-          await this.onAnalyticUnitSave(analyticUnit);
-        }
-        this.analyticsController.runDetect(
-          analyticUnit.id,
-          from, to
-        )
+        await this._runDetectInCurrentRange(analyticUnit);
       };
       appEvents.emit('show-modal', {
         src: `${this.partialsPath}/relearning_confirmation.html`,
         scope: modalScope
       });
-      return;
+    } else {
+      await this._runDetectInCurrentRange(analyticUnit);
     }
+  }
+
+  async _runDetectInCurrentRange(analyticUnit: AnalyticUnit) {
+    const { from, to } = this.rangeTimestamp;
+
+    if(analyticUnit.changed) {
+      await this.onAnalyticUnitSave(analyticUnit);
+    }
+    this.analyticsController.runDetect(
+      analyticUnit.id,
+      from, to
+    )
 
     if(analyticUnit.changed) {
       await this.onAnalyticUnitSave(analyticUnit);

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -623,6 +623,24 @@ class GraphCtrl extends MetricsPanelCtrl {
   async runDetectInCurrentRange(analyticUnit: AnalyticUnit) {
     const { from, to } = this.rangeTimestamp;
 
+    if(analyticUnit.status === 'LEARNING' || analyticUnit.saving) {
+      let modalScope = this.$scope.$new(true);
+      modalScope.confirm = async () => {
+        if(analyticUnit.changed) {
+          await this.onAnalyticUnitSave(analyticUnit);
+        }
+        this.analyticsController.runDetect(
+          analyticUnit.id,
+          from, to
+        )
+      };
+      appEvents.emit('show-modal', {
+        src: `${this.partialsPath}/relearning_confirmation.html`,
+        scope: modalScope
+      });
+      return;
+    }
+
     if(analyticUnit.changed) {
       await this.onAnalyticUnitSave(analyticUnit);
     }

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -620,8 +620,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.analyticsController.redetectAll(from, to);
   }
 
-  async runDetectInCurrentRange(analyticUnit: AnalyticUnit) {
-    if(analyticUnit.status === 'LEARNING' || analyticUnit.saving) {
+  async runDetectInCurrentRange(analyticUnit: AnalyticUnit): Promise<void> {
+    if(analyticUnit.status === 'LEARNING') {
       let modalScope = this.$scope.$new(true);
       modalScope.confirm = async () => {
         await this._runDetectInCurrentRange(analyticUnit);
@@ -635,7 +635,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     }
   }
 
-  async _runDetectInCurrentRange(analyticUnit: AnalyticUnit) {
+  async _runDetectInCurrentRange(analyticUnit: AnalyticUnit): Promise<void> {
     const { from, to } = this.rangeTimestamp;
 
     if(analyticUnit.changed) {

--- a/src/panel/graph_panel/partials/analytic_units_5.x.html
+++ b/src/panel/graph_panel/partials/analytic_units_5.x.html
@@ -126,6 +126,7 @@
 
     <label class="gf-form-label"
       ng-click="ctrl.runDetectInCurrentRange(analyticUnit)"
+      ng-disabled="analyticUnit.saving"
       bs-tooltip="'Learn & Detect'"
     >
       <a class="pointer">

--- a/src/panel/graph_panel/partials/analytic_units_5.x.html
+++ b/src/panel/graph_panel/partials/analytic_units_5.x.html
@@ -126,7 +126,6 @@
 
     <label class="gf-form-label"
       ng-click="ctrl.runDetectInCurrentRange(analyticUnit)"
-      ng-disabled="analyticUnit.status === 'LEARNING' || analyticUnit.saving"
       bs-tooltip="'Learn & Detect'"
     >
       <a class="pointer">

--- a/src/panel/graph_panel/partials/analytic_units_6.x.html
+++ b/src/panel/graph_panel/partials/analytic_units_6.x.html
@@ -115,7 +115,6 @@
 
       <button class="query-editor-row__action"
         ng-click="ctrl.runDetectInCurrentRange(analyticUnit)"
-        ng-disabled="analyticUnit.status === 'LEARNING' || analyticUnit.saving"
         bs-tooltip="'Learn & Detect'"
       >
         <a class="pointer">

--- a/src/panel/graph_panel/partials/analytic_units_6.x.html
+++ b/src/panel/graph_panel/partials/analytic_units_6.x.html
@@ -115,6 +115,7 @@
 
       <button class="query-editor-row__action"
         ng-click="ctrl.runDetectInCurrentRange(analyticUnit)"
+        ng-disabled="analyticUnit.saving"
         bs-tooltip="'Learn & Detect'"
       >
         <a class="pointer">

--- a/src/panel/graph_panel/partials/relearning_confirmation.html
+++ b/src/panel/graph_panel/partials/relearning_confirmation.html
@@ -15,7 +15,7 @@
   <div class="modal-content text-center">
     <div class="confirm-modal-text">
       <span>
-        Analytic is learning. Do you want to cancel it and re-learn?
+        Analytic unit is learning. Do you want to cancel it and re-learn?
       </span>
     </div>
 

--- a/src/panel/graph_panel/partials/relearning_confirmation.html
+++ b/src/panel/graph_panel/partials/relearning_confirmation.html
@@ -1,0 +1,27 @@
+<div class="modal-body" ng-cloak>
+  <div class="modal-header">
+    <h2 class="modal-header-title">
+      <i class="fa"></i>
+      <span class="p-l-1">
+        Confirm re-learning
+      </span>
+    </h2>
+
+    <a class="modal-header-close" ng-click="dismiss()">
+      <i class="fa fa-remove"></i>
+    </a>
+  </div>
+  
+  <div class="modal-content text-center">
+    <div class="confirm-modal-text">
+      <span>
+        Analytic is learning. Do you want to cancel it and re-learn?
+      </span>
+    </div>
+
+    <div class="confirm-modal-buttons">
+      <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+      <button type="button" class="btn btn-danger btn-ok" data-dismiss="modal" ng-click="confirm()">Yes</button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
fixes #401

This PR:
 *  removes disabling of `Apply` button for case when analytic unit is in LEARNING state 
 * adds confirmation dialog for analytic unit's re-learning
![image](https://user-images.githubusercontent.com/5675912/73069674-5f7e2680-3ebf-11ea-957b-9a8f7013e608.png)

Note: `analyticUnit.saving` is the flag that represents that panel waits while a server saves an analytic unit. it becomes `true` when a saving request will be sent and become `false` when a response will be received.

## Changes
* new `partials/relearning_confirmation.html` with confirmation modal dialog
* `graph_panel/graph_ctrl.ts` creates modal dialog that contains callback for the "Confirm" button. callback runs re-learning and re-detection
* do not disable "Apply" button for analytic units in LEARNING state