### PR TITLE
"Export analytic units" button

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -115,6 +115,10 @@ export class AnalyticController {
     this._creatingNewAnalyticUnit = false;
   }
 
+  async exportAnalyticUnits(): Promise<object> {
+    return this._analyticService.exportAnalyticUnits(this._panelId);
+  }
+
   async saveNew(metric: MetricExpanded, datasource: DatasourceRequest) {
     this._savingNewAnalyticUnit = true;
     const newAnalyticUnit = createAnalyticUnit(this._newAnalyticUnit.toJSON());

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -302,9 +302,10 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.subTabIndex = 0;
   }
 
-  onInitPanelActions(actions) {
+  onInitPanelActions(actions: { text: string, click: string }[]): void {
     actions.push({ text: 'Export CSV', click: 'ctrl.exportCsv()' });
     actions.push({ text: 'Toggle legend', click: 'ctrl.toggleLegend()' });
+    actions.push({ text: 'Export analytic units', click: 'ctrl.exportAnalyticUnits()' });
   }
 
   async onHasticDatasourceChange() {
@@ -549,6 +550,14 @@ class GraphCtrl extends MetricsPanelCtrl {
       templateHtml: '<export-data-modal data="seriesList"></export-data-modal>',
       scope,
       modalClass: 'modal--narrow',
+    });
+  }
+
+  async exportAnalyticUnits(): Promise<void> {
+    const json = await this.analyticsController.exportAnalyticUnits();
+    this.publishAppEvent('show-modal', {
+      src: 'public/app/partials/edit_json.html',
+      model: { object: json, enableCopy: true }
     });
   }
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -62,7 +62,7 @@ export class AnalyticService {
   }
 
   async exportAnalyticUnits(panelId: string): Promise<object> {
-    const resp = await this.get('/panel/template', { panelId });
+    const resp = await this.get('/panels/template', { panelId });
     if(resp === undefined) {
       return {};
     }

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -62,7 +62,7 @@ export class AnalyticService {
   }
 
   async exportAnalyticUnits(panelId: string): Promise<object> {
-    const resp = await this.get('/analyticUnits/json', { panelId });
+    const resp = await this.get('/panel/template', { panelId });
     if(resp === undefined) {
       return {};
     }

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -61,6 +61,14 @@ export class AnalyticService {
     return resp.analyticUnits;
   }
 
+  async exportAnalyticUnits(panelId: string): Promise<object> {
+    const resp = await this.get('/analyticUnits/json', { panelId });
+    if(resp === undefined) {
+      return {};
+    }
+    return resp;
+  }
+
   async postNewAnalyticUnit(
     analyticUnit: AnalyticUnit,
     metric: MetricExpanded,


### PR DESCRIPTION
This PR adds "Export analytic units" button to the hastic-graph-panel menu.
![image](https://user-images.githubusercontent.com/1989898/73276967-907d9480-41fa-11ea-86d0-8d6ede77a5a3.png)

When user clicks on the button, panel fetches and displays JSON from hastic-server. The JSON contains:
- analytic unit templates (analytic units with some fields changed to variables)
- analytic unit caches
- segments
- detection spans
![image](https://user-images.githubusercontent.com/1989898/73277067-af7c2680-41fa-11ea-9781-aa44a66ecc93.png)

This JSON can be imported to another hastic-server instance after implementing https://github.com/hastic/hastic-server/issues/830
