### PR TITLE
Import analytic units

### DIFF
--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -17,6 +17,7 @@ import { SegmentArray } from '../models/segment_array';
 import { HasticServerInfo, HasticServerInfoUnknown } from '../models/hastic_server_info';
 import { Condition } from '../models/analytic_units/threshold_analytic_unit';
 import { DetectionStatus, DETECTION_STATUS_TEXT, DetectionSpan } from '../models/detection';
+import { PanelTemplate, TemplateVariables } from '../models/panel';
 import { createAnalyticUnit } from '../models/analytic_units/utils';
 import helpSectionText from '../partials/help_section.html';
 
@@ -115,13 +116,13 @@ export class AnalyticController {
     this._creatingNewAnalyticUnit = false;
   }
 
-  async exportPanel(): Promise<any> {
+  async exportPanel(): Promise<PanelTemplate> {
     return this._analyticService.exportPanel(this._panelId);
   }
 
   async importPanel(
-    panelTemplate: any,
-    templateVariables: { grafanaUrl: string, panelId: string, datasourceUrl: string }
+    panelTemplate: PanelTemplate,
+    templateVariables: TemplateVariables
   ): Promise<void> {
     return this._analyticService.importPanel(panelTemplate, templateVariables);
   }

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -115,7 +115,7 @@ export class AnalyticController {
     this._creatingNewAnalyticUnit = false;
   }
 
-  async exportPanel(): Promise<object> {
+  async exportPanel(): Promise<any> {
     return this._analyticService.exportPanel(this._panelId);
   }
 

--- a/src/panel/graph_panel/controllers/analytic_controller.ts
+++ b/src/panel/graph_panel/controllers/analytic_controller.ts
@@ -115,8 +115,15 @@ export class AnalyticController {
     this._creatingNewAnalyticUnit = false;
   }
 
-  async exportAnalyticUnits(): Promise<object> {
-    return this._analyticService.exportAnalyticUnits(this._panelId);
+  async exportPanel(): Promise<object> {
+    return this._analyticService.exportPanel(this._panelId);
+  }
+
+  async importPanel(
+    panelTemplate: any,
+    templateVariables: { grafanaUrl: string, panelId: string, datasourceUrl: string }
+  ): Promise<void> {
+    return this._analyticService.importPanel(panelTemplate, templateVariables);
   }
 
   async saveNew(metric: MetricExpanded, datasource: DatasourceRequest) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -12,6 +12,7 @@ import { BOUND_TYPES } from './models/analytic_units/anomaly_analytic_unit';
 import { AnalyticService } from './services/analytic_service';
 import { AnalyticController } from './controllers/analytic_controller';
 import { HasticPanelInfo } from './models/hastic_panel_info';
+import { PanelTemplate, TemplateVariables } from './models/panel';
 import { axesEditorComponent } from './axes_editor';
 
 import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';
@@ -67,7 +68,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     to?: number
   };
 
-  public panelTemplate = {};
+  public panelTemplate: PanelTemplate = {};
 
   panelDefaults = {
     // datasource name, null = default datasource
@@ -559,10 +560,10 @@ class GraphCtrl extends MetricsPanelCtrl {
   }
 
   async exportPanel(): Promise<void> {
-    const json = await this.analyticsController.exportPanel();
+    const panelTemplate = await this.analyticsController.exportPanel();
     this.publishAppEvent('show-modal', {
       src: 'public/app/partials/edit_json.html',
-      model: { object: json, enableCopy: true }
+      model: { object: panelTemplate, enableCopy: true }
     });
   }
 
@@ -591,11 +592,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     });
   }
 
-  // TODO: not any
-  async importPanel(
-    panelTemplate: any,
-    templateVariables: { grafanaUrl: string, panelId: string, datasourceUrl: string }
-  ): Promise<void> {
+  async importPanel(panelTemplate: PanelTemplate, templateVariables: TemplateVariables): Promise<void> {
     // TODO: show import errors properly
     await this.analyticsController.importPanel(panelTemplate, templateVariables);
   }

--- a/src/panel/graph_panel/models/panel.ts
+++ b/src/panel/graph_panel/models/panel.ts
@@ -1,0 +1,12 @@
+export type PanelTemplate = {
+  analyticUnits?: any[],
+  caches?: any[],
+  detectionSpans?: any[],
+  segments?: any[]
+}
+
+export type TemplateVariables = {
+  grafanaUrl: string,
+  panelId: string,
+  datasourceUrl: string
+};

--- a/src/panel/graph_panel/partials/import_panel.html
+++ b/src/panel/graph_panel/partials/import_panel.html
@@ -1,0 +1,21 @@
+<div id="import-analytic-units">
+  <div class="tabbed-view-header">
+    <h2 class="tabbed-view-title">
+      JSON
+    </h2>
+
+    <button class="tabbed-view-close-btn" ng-click="dismiss()">
+      <i class="fa fa-remove"></i>
+    </button>
+  </div>
+
+  <div class="tabbed-view-body">
+    <div class="gf-form">
+      <code-editor content="panelTemplate" data-mode="json" data-max-lines="20"></code-editor>
+    </div>
+
+    <div class="gf-form-button-row">
+      <button type="button" class="btn btn-primary" ng-click="import(panelTemplate); dismiss();">Import</button>
+    </div>
+  </div>
+</div>

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -61,7 +61,7 @@ export class AnalyticService {
     return resp.analyticUnits;
   }
 
-  async exportPanel(panelId: string): Promise<object> {
+  async exportPanel(panelId: string): Promise<any> {
     const resp = await this.get('/panels/template', { panelId });
     if(resp === undefined) {
       return {};

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -61,12 +61,19 @@ export class AnalyticService {
     return resp.analyticUnits;
   }
 
-  async exportAnalyticUnits(panelId: string): Promise<object> {
+  async exportPanel(panelId: string): Promise<object> {
     const resp = await this.get('/panels/template', { panelId });
     if(resp === undefined) {
       return {};
     }
     return resp;
+  }
+
+  async importPanel(
+    panelTemplate: any,
+    templateVariables: { grafanaUrl: string, panelId: string, datasourceUrl: string }
+  ): Promise<void> {
+    await this.post('/panels/template', { panelTemplate, templateVariables });
   }
 
   async postNewAnalyticUnit(

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -5,6 +5,7 @@ import { SegmentsSet } from '../models/segment_set';
 import { AnalyticUnitId, AnalyticUnit, AnalyticSegment } from '../models/analytic_units/analytic_unit';
 import { HasticServerInfo, HasticServerInfoUnknown } from '../models/hastic_server_info';
 import { DetectionSpan } from '../models/detection';
+import { PanelTemplate, TemplateVariables } from '../models/panel';
 
 import { isHasticServerResponse, isSupportedServerVersion, SUPPORTED_SERVER_VERSION } from '../../../utils';
 
@@ -61,7 +62,7 @@ export class AnalyticService {
     return resp.analyticUnits;
   }
 
-  async exportPanel(panelId: string): Promise<any> {
+  async exportPanel(panelId: string): Promise<PanelTemplate> {
     const resp = await this.get('/panels/template', { panelId });
     if(resp === undefined) {
       return {};
@@ -70,8 +71,8 @@ export class AnalyticService {
   }
 
   async importPanel(
-    panelTemplate: any,
-    templateVariables: { grafanaUrl: string, panelId: string, datasourceUrl: string }
+    panelTemplate: PanelTemplate,
+    templateVariables: TemplateVariables
   ): Promise<void> {
     await this.post('/panels/template', { panelTemplate, templateVariables });
   }


### PR DESCRIPTION
This PR adds an ability to import analytic units with cache / segments / detection spans.

![image](https://user-images.githubusercontent.com/1989898/74177795-7f497480-4c4b-11ea-8e35-9f6087afafb6.png)

## Changes
- new "Import analytic units" button
- new "Import analytic units" modal with JSON field

## Known issues
- we should add inputs for template variables: Grafana URL, panel ID and datasource URL to the "Import analytic units" modal. Now default panel values are used.
- import errors are not displayed