### PR TITLE
UX fixes

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -323,8 +323,8 @@ class GraphCtrl extends MetricsPanelCtrl {
       delete this.analyticService;
     } else {
       this.analyticService = new AnalyticService(hasticDatasource.url, this.$http);
-      await this.analyticService.checkDatasourceAvailability();
-      if(this.analyticService.isUp) {
+      const isHasticAvailable = await this.analyticService.checkDatasourceAvailability();
+      if(isHasticAvailable) {
         this.updateAnalyticUnitTypes();
       }
     }

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -323,8 +323,8 @@ class GraphCtrl extends MetricsPanelCtrl {
       delete this.analyticService;
     } else {
       this.analyticService = new AnalyticService(hasticDatasource.url, this.$http);
-      const isDatasourceAvailable = await this.analyticService.isDatasourceAvailable();
-      if(isDatasourceAvailable) {
+      await this.analyticService.checkDatasourceAvailability();
+      if(this.analyticService.isUp) {
         this.updateAnalyticUnitTypes();
       }
     }

--- a/src/panel/graph_panel/partials/reconnect_to_datasource.html
+++ b/src/panel/graph_panel/partials/reconnect_to_datasource.html
@@ -1,0 +1,7 @@
+<div class="gf-form-button-row" ng-if="ctrl.hasticDatasource !== undefined && ctrl.analyticsController.serverStatus === false">
+  <h5>Hastic server at "{{ctrl.hasticDatasource.url}}" is not available</h5>
+  <button class="btn btn-inverse" ng-click="ctrl.onHasticDatasourceChange()">
+    <i class="fa fa-plug"></i>
+    Reconnect to Hastic server
+  </button>
+</div>

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -10,13 +10,7 @@
 </div>
 
 <div>
-  <div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
-    <h5>Hastic server at "{{ctrl.hasticDatasource.url}}" is not available</h5>
-    <button class="btn btn-inverse" ng-click="ctrl.onHasticDatasourceChange()">
-      <i class="fa fa-plug"></i>
-      Reconnect to Hastic server
-    </button>
-  </div>
+  <ng-include src="ctrl.partialsPath + '/reconnect_to_datasource.html'" />
 
   <div ng-if="ctrl.analyticsController.serverStatus === true && !ctrl.analyticsController.loading">
     <ng-include src="ctrl.getTemplatePath('analytic_units')">

--- a/src/panel/graph_panel/partials/tab_webhooks.html
+++ b/src/panel/graph_panel/partials/tab_webhooks.html
@@ -1,10 +1,4 @@
-<div class="gf-form-button-row" ng-if="ctrl.analyticsController.serverStatus === false">
-  <h5>Hastic server at "{{ctrl.hasticDatasource.url}}" is not available</h5>
-  <button class="btn btn-inverse" ng-click="ctrl.runBackendConnectivityCheck()">
-    <i class="fa fa-plug"></i>
-    Reconnect to Hastic server
-  </button>
-</div>
+<ng-include src="ctrl.partialsPath + '/reconnect_to_datasource.html'" />
 
 <div ng-if="ctrl.analyticsController.serverStatus === true">
   <div ng-if="!ctrl.analyticsController.analyticUnits.length">

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -306,9 +306,9 @@ export class AnalyticService {
         // -1 usually means the request was aborted, e.g. using a config.timeout
         // See: https://docs.angularjs.org/api/ng/service/$http#$http-returns
         if(error.status === 504 || error.status === -1) {
-          this.displayConnectionTimeoutAlert(statusText);
+          this._displayConnectionTimeoutAlert(statusText);
         } else {
-          this.displayNoConnectionAlert(statusText);
+          this._displayNoConnectionAlert(statusText);
         }
         this._isUp = false;
         throw new Error(`Fetching error: ${statusText}`);
@@ -352,7 +352,7 @@ export class AnalyticService {
     return this._analyticRequest('DELETE', url, data);
   }
 
-  private displayNoConnectionAlert(statusText: string) {
+  private _displayNoConnectionAlert(statusText: string): void {
     const message = [
       `No connection to Hastic Server. Status: ${statusText}`,
       `Hastic Datasource URL: "${this._hasticDatasourceURL}"`,
@@ -360,7 +360,7 @@ export class AnalyticService {
     this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
-  private displayConnectionTimeoutAlert(statusText: string) {
+  private _displayConnectionTimeoutAlert(statusText: string): void {
     const message = [
       `Timeout when connecting to Hastic Server. Status: ${statusText}`,
       `Hastic Datasource URL: "${this._hasticDatasourceURL}"`,
@@ -368,7 +368,7 @@ export class AnalyticService {
     this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
-  private displayWrongUrlAlert() {
+  private displayWrongUrlAlert(): void {
     const message = [
       'Please check Hastic Server URL',
       `Something is working at "${this._hasticDatasourceURL}" but it's not Hastic Server`,
@@ -376,7 +376,7 @@ export class AnalyticService {
     this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
-  private displayUnsupportedVersionAlert(actual: string) {
+  private displayUnsupportedVersionAlert(actual: string): void {
     const message = [
       'Unsupported Hastic Server version',
       `Hastic Server at "${this._hasticDatasourceURL}" has unsupported version (got ${actual}, should be ${SUPPORTED_SERVER_VERSION})`,

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -266,8 +266,9 @@ export class AnalyticService {
     });
   }
 
-  async checkDatasourceAvailability(): Promise<void> {
+  async checkDatasourceAvailability(): Promise<boolean> {
     this._isUp = await this._isDatasourceAvailable();
+    return this._isUp;
   }
 
   async updateAnalyticUnit(updateObj: any) {


### PR DESCRIPTION
This PR fixes UX bugs.

# Changes:
- do not show "Reconnect" button if hastic datasource is not selected
- show status code and status text when hastic datasource is not available

# Do not show "Reconnect" button if hastic datasource is not selected

## Before
![image](https://user-images.githubusercontent.com/1989898/74870365-a817eb00-536a-11ea-8603-1653ae2e3523.png)

## After
![image](https://user-images.githubusercontent.com/1989898/74870416-b960f780-536a-11ea-9f1c-741a38abd733.png)

# Show status code and status text when hastic datasource is not available

## Before
![image](https://user-images.githubusercontent.com/1989898/74870617-13fa5380-536b-11ea-976f-b6df62a667a7.png)

## After
![image](https://user-images.githubusercontent.com/1989898/74870600-0cd34580-536b-11ea-98b6-138858019efd.png)