### PR TITLE
Show progress when reconnecting to hastic datasource #412

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -9,7 +9,7 @@ import { MetricExpanded } from './models/metric';
 import { DatasourceRequest } from './models/datasource';
 import { AnalyticUnitId, AnalyticUnit, LabelingMode } from './models/analytic_units/analytic_unit';
 import { BOUND_TYPES } from './models/analytic_units/anomaly_analytic_unit';
-import { AnalyticService, HasticDatasourceTestingStatus } from './services/analytic_service';
+import { AnalyticService, HasticDatasourceConnectingStatus } from './services/analytic_service';
 import { AnalyticController } from './controllers/analytic_controller';
 import { HasticPanelInfo } from './models/hastic_panel_info';
 import { PanelTemplate, TemplateVariables } from './models/panel';
@@ -353,8 +353,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
   }
 
-  get testingStatus(): HasticDatasourceTestingStatus {
-    return this.analyticService.testingStatus;
+  get connectingStatus(): HasticDatasourceConnectingStatus {
+    return this.analyticService.connectingStatus;
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -9,7 +9,7 @@ import { MetricExpanded } from './models/metric';
 import { DatasourceRequest } from './models/datasource';
 import { AnalyticUnitId, AnalyticUnit, LabelingMode } from './models/analytic_units/analytic_unit';
 import { BOUND_TYPES } from './models/analytic_units/anomaly_analytic_unit';
-import { AnalyticService, HasticDatasourceStatus } from './services/analytic_service';
+import { AnalyticService, HasticDatasourceTestingStatus } from './services/analytic_service';
 import { AnalyticController } from './controllers/analytic_controller';
 import { HasticPanelInfo } from './models/hastic_panel_info';
 import { PanelTemplate, TemplateVariables } from './models/panel';
@@ -353,8 +353,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
   }
 
-  get hasticDatasourceStatus(): HasticDatasourceStatus {
-    return this.analyticService.hasticDatasourceStatus;
+  get testingStatus(): HasticDatasourceTestingStatus {
+    return this.analyticService.testingStatus;
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -9,7 +9,7 @@ import { MetricExpanded } from './models/metric';
 import { DatasourceRequest } from './models/datasource';
 import { AnalyticUnitId, AnalyticUnit, LabelingMode } from './models/analytic_units/analytic_unit';
 import { BOUND_TYPES } from './models/analytic_units/anomaly_analytic_unit';
-import { AnalyticService, HasticDatasourceConnectingStatus } from './services/analytic_service';
+import { AnalyticService, HasticDatasourceConnectionStatus } from './services/analytic_service';
 import { AnalyticController } from './controllers/analytic_controller';
 import { HasticPanelInfo } from './models/hastic_panel_info';
 import { PanelTemplate, TemplateVariables } from './models/panel';
@@ -353,8 +353,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.refresh();
   }
 
-  get connectingStatus(): HasticDatasourceConnectingStatus {
-    return this.analyticService.connectingStatus;
+  get connectionStatus(): HasticDatasourceConnectionStatus {
+    return this.analyticService.connectionStatus;
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -9,7 +9,7 @@ import { MetricExpanded } from './models/metric';
 import { DatasourceRequest } from './models/datasource';
 import { AnalyticUnitId, AnalyticUnit, LabelingMode } from './models/analytic_units/analytic_unit';
 import { BOUND_TYPES } from './models/analytic_units/anomaly_analytic_unit';
-import { AnalyticService } from './services/analytic_service';
+import { AnalyticService, HasticDatasourceStatus } from './services/analytic_service';
 import { AnalyticController } from './controllers/analytic_controller';
 import { HasticPanelInfo } from './models/hastic_panel_info';
 import { PanelTemplate, TemplateVariables } from './models/panel';
@@ -351,6 +351,10 @@ class GraphCtrl extends MetricsPanelCtrl {
     this._graphLegend = new GraphLegend(this.$legendElem, this.popoverSrv, this.$scope, this.analyticsController);
 
     this.refresh();
+  }
+
+  get hasticDatasourceStatus(): HasticDatasourceStatus {
+    return this.analyticService.hasticDatasourceStatus;
   }
 
   issueQueries(datasource) {

--- a/src/panel/graph_panel/partials/reconnect_to_datasource.html
+++ b/src/panel/graph_panel/partials/reconnect_to_datasource.html
@@ -1,16 +1,16 @@
 <div class="gf-form-button-row" ng-if="ctrl.hasticDatasource !== undefined && ctrl.analyticsController.serverStatus === false">
   <div class="gf-form-group">
-    <div class="alert-{{ctrl.testingStatus.status}} alert"">
+    <div class="alert-{{ctrl.connectingStatus.status}} alert"">
       <div class="alert-icon">
-        <i class="fa fa-spiner fa-spin" ng-show="ctrl.testingStatus.status === 'info'"></i>
-        <i class="fa fa-exclamation-triangle" ng-show="ctrl.testingStatus.status === 'error'"></i>
-        <i class="fa fa-check" ng-show="ctrl.testingStatus.status !== 'error'"></i>
+        <i class="fa fa-spiner fa-spin" ng-show="ctrl.connectingStatus.status === 'info'"></i>
+        <i class="fa fa-exclamation-triangle" ng-show="ctrl.connectingStatus.status === 'error'"></i>
+        <i class="fa fa-check" ng-show="ctrl.connectingStatus.status !== 'error'"></i>
       </div>
       <div class="alert-body">
-        <div class="alert-title" ng-bind-html="ctrl.testingStatus.message" />
+        <div class="alert-title" ng-bind-html="ctrl.connectingStatus.message" />
       </div>
     </div>
-    <div ng-hide="ctrl.testingStatus.status === 'info'">
+    <div ng-hide="ctrl.connectingStatus.status === 'info'">
       <button class="btn btn-secondary" ng-click="ctrl.onHasticDatasourceChange()">
         <i class="fa fa-plug"></i>
         &nbsp; Connect to Hastic Datasource

--- a/src/panel/graph_panel/partials/reconnect_to_datasource.html
+++ b/src/panel/graph_panel/partials/reconnect_to_datasource.html
@@ -1,7 +1,20 @@
 <div class="gf-form-button-row" ng-if="ctrl.hasticDatasource !== undefined && ctrl.analyticsController.serverStatus === false">
-  <h5>Hastic server at "{{ctrl.hasticDatasource.url}}" is not available</h5>
-  <button class="btn btn-inverse" ng-click="ctrl.onHasticDatasourceChange()">
-    <i class="fa fa-plug"></i>
-    Reconnect to Hastic server
-  </button>
+  <div class="gf-form-group">
+    <div class="alert-{{ctrl.hasticDatasourceStatus.status}} alert"">
+      <div class="alert-icon">
+        <i class="fa fa-spiner fa-spin" ng-show="ctrl.hasticDatasourceStatus.testing"></i>
+        <i class="fa fa-exclamation-triangle" ng-show="ctrl.hasticDatasourceStatus.status === 'error'"></i>
+        <i class="fa fa-check" ng-show="ctrl.hasticDatasourceStatus.status !== 'error'"></i>
+      </div>
+      <div class="alert-body">
+        <div class="alert-title" ng-bind-html="ctrl.hasticDatasourceStatus.message" />
+      </div>
+    </div>
+    <div ng-hide="ctrl.hasticDatasourceStatus.testing">
+      <button class="btn btn-secondary" ng-click="ctrl.onHasticDatasourceChange()">
+        <i class="fa fa-plug"></i>
+        &nbsp; Connect to Hastic Datasource
+      </button>
+    </div>
+  </div>
 </div>

--- a/src/panel/graph_panel/partials/reconnect_to_datasource.html
+++ b/src/panel/graph_panel/partials/reconnect_to_datasource.html
@@ -1,16 +1,16 @@
 <div class="gf-form-button-row" ng-if="ctrl.hasticDatasource !== undefined && ctrl.analyticsController.serverStatus === false">
   <div class="gf-form-group">
-    <div class="alert-{{ctrl.hasticDatasourceStatus.status}} alert"">
+    <div class="alert-{{ctrl.testingStatus.status}} alert"">
       <div class="alert-icon">
-        <i class="fa fa-spiner fa-spin" ng-show="ctrl.hasticDatasourceStatus.testing"></i>
-        <i class="fa fa-exclamation-triangle" ng-show="ctrl.hasticDatasourceStatus.status === 'error'"></i>
-        <i class="fa fa-check" ng-show="ctrl.hasticDatasourceStatus.status !== 'error'"></i>
+        <i class="fa fa-spiner fa-spin" ng-show="ctrl.testingStatus.testing"></i>
+        <i class="fa fa-exclamation-triangle" ng-show="ctrl.testingStatus.status === 'error'"></i>
+        <i class="fa fa-check" ng-show="ctrl.testingStatus.status !== 'error'"></i>
       </div>
       <div class="alert-body">
-        <div class="alert-title" ng-bind-html="ctrl.hasticDatasourceStatus.message" />
+        <div class="alert-title" ng-bind-html="ctrl.testingStatus.message" />
       </div>
     </div>
-    <div ng-hide="ctrl.hasticDatasourceStatus.testing">
+    <div ng-hide="ctrl.testingStatus.testing">
       <button class="btn btn-secondary" ng-click="ctrl.onHasticDatasourceChange()">
         <i class="fa fa-plug"></i>
         &nbsp; Connect to Hastic Datasource

--- a/src/panel/graph_panel/partials/reconnect_to_datasource.html
+++ b/src/panel/graph_panel/partials/reconnect_to_datasource.html
@@ -2,7 +2,7 @@
   <div class="gf-form-group">
     <div class="alert-{{ctrl.testingStatus.status}} alert"">
       <div class="alert-icon">
-        <i class="fa fa-spiner fa-spin" ng-show="ctrl.testingStatus.testing"></i>
+        <i class="fa fa-spiner fa-spin" ng-show="ctrl.testingStatus.status === 'info'"></i>
         <i class="fa fa-exclamation-triangle" ng-show="ctrl.testingStatus.status === 'error'"></i>
         <i class="fa fa-check" ng-show="ctrl.testingStatus.status !== 'error'"></i>
       </div>
@@ -10,7 +10,7 @@
         <div class="alert-title" ng-bind-html="ctrl.testingStatus.message" />
       </div>
     </div>
-    <div ng-hide="ctrl.testingStatus.testing">
+    <div ng-hide="ctrl.testingStatus.status === 'info'">
       <button class="btn btn-secondary" ng-click="ctrl.onHasticDatasourceChange()">
         <i class="fa fa-plug"></i>
         &nbsp; Connect to Hastic Datasource

--- a/src/panel/graph_panel/partials/reconnect_to_datasource.html
+++ b/src/panel/graph_panel/partials/reconnect_to_datasource.html
@@ -1,16 +1,16 @@
 <div class="gf-form-button-row" ng-if="ctrl.hasticDatasource !== undefined && ctrl.analyticsController.serverStatus === false">
   <div class="gf-form-group">
-    <div class="alert-{{ctrl.connectingStatus.status}} alert"">
+    <div class="alert-{{ctrl.connectionStatus.status}} alert"">
       <div class="alert-icon">
-        <i class="fa fa-spiner fa-spin" ng-show="ctrl.connectingStatus.status === 'info'"></i>
-        <i class="fa fa-exclamation-triangle" ng-show="ctrl.connectingStatus.status === 'error'"></i>
-        <i class="fa fa-check" ng-show="ctrl.connectingStatus.status !== 'error'"></i>
+        <i class="fa fa-spiner fa-spin" ng-show="ctrl.connectionStatus.status === 'info'"></i>
+        <i class="fa fa-exclamation-triangle" ng-show="ctrl.connectionStatus.status === 'error'"></i>
+        <i class="fa fa-check" ng-show="ctrl.connectionStatus.status !== 'error'"></i>
       </div>
       <div class="alert-body">
-        <div class="alert-title" ng-bind-html="ctrl.connectingStatus.message" />
+        <div class="alert-title" ng-bind-html="ctrl.connectionStatus.message" />
       </div>
     </div>
-    <div ng-hide="ctrl.connectingStatus.status === 'info'">
+    <div ng-hide="ctrl.connectionStatus.status === 'info'">
       <button class="btn btn-secondary" ng-click="ctrl.onHasticDatasourceChange()">
         <i class="fa fa-plug"></i>
         &nbsp; Connect to Hastic Datasource

--- a/src/panel/graph_panel/partials/tab_webhooks.html
+++ b/src/panel/graph_panel/partials/tab_webhooks.html
@@ -1,5 +1,3 @@
-<ng-include src="ctrl.partialsPath + '/reconnect_to_datasource.html'" />
-
 <div ng-if="ctrl.analyticsController.serverStatus === true">
   <div ng-if="!ctrl.analyticsController.analyticUnits.length">
     <h5> Please create at least 1 analytic unit to enable webhooks </h5>

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -15,7 +15,7 @@ import * as _ from 'lodash';
 
 
 declare global {
-  interface Window { hasticDatasourcesAvailability: { [key: string]: HasticDatasourceAvailability } }
+  interface Window { hasticDatasourcesAvailability: { [key: string]: HasticDatasourceStatus } }
 }
 
 // TODO: TableTimeSeries is bad name
@@ -24,21 +24,21 @@ export type TableTimeSeries = {
   columns: string[];
 };
 
-export enum HasticDatasourceAvailability {
+export enum HasticDatasourceStatus {
   AVAILABLE = 'success',
   NOT_AVAILABLE = 'error'
 };
 
-export type HasticDatasourceStatus = {
+export type HasticDatasourceTestingStatus = {
   testing: boolean,
-  availability: HasticDatasourceAvailability,
+  status: HasticDatasourceStatus,
   message: string
 }
 
 export class AnalyticService {
-  public hasticDatasourceStatus: HasticDatasourceStatus = {
+  public testingStatus: HasticDatasourceTestingStatus = {
     testing: false,
-    availability: HasticDatasourceAvailability.NOT_AVAILABLE,
+    status: HasticDatasourceStatus.NOT_AVAILABLE,
     message: ''
   };
 
@@ -137,7 +137,7 @@ export class AnalyticService {
         'Connected to Hastic Datasource',
         `Hastic datasource URL: "${this._hasticDatasourceURL}"`
       ];
-      this._displayConnectionAlert(HasticDatasourceAvailability.AVAILABLE, message);
+      this._displayConnectionAlert(HasticDatasourceStatus.AVAILABLE, message);
 
       return true;
     } catch(e) {
@@ -274,11 +274,11 @@ export class AnalyticService {
   }
 
   async checkDatasourceAvailability(): Promise<boolean> {
-    this.hasticDatasourceStatus.testing = true;
+    this.testingStatus.testing = true;
 
     this._isUp = await this._isDatasourceAvailable();
 
-    this.hasticDatasourceStatus.testing = false;
+    this.testingStatus.testing = false;
     return this._isUp;
   }
 
@@ -368,7 +368,7 @@ export class AnalyticService {
       `No connection to Hastic Server. Status: ${statusText}`,
       `Hastic Datasource URL: "${this._hasticDatasourceURL}"`,
     ]
-    this._displayConnectionAlert(HasticDatasourceAvailability.NOT_AVAILABLE, message);
+    this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
   private _displayConnectionTimeoutAlert(statusText: string): void {
@@ -376,7 +376,7 @@ export class AnalyticService {
       `Timeout when connecting to Hastic Server. Status: ${statusText}`,
       `Hastic Datasource URL: "${this._hasticDatasourceURL}"`,
     ]
-    this._displayConnectionAlert(HasticDatasourceAvailability.NOT_AVAILABLE, message);
+    this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
   private displayWrongUrlAlert(): void {
@@ -384,7 +384,7 @@ export class AnalyticService {
       'Please check Hastic Server URL',
       `Something is working at "${this._hasticDatasourceURL}" but it's not Hastic Server`,
     ]
-    this._displayConnectionAlert(HasticDatasourceAvailability.NOT_AVAILABLE, message);
+    this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
   private displayUnsupportedVersionAlert(actual: string): void {
@@ -392,16 +392,16 @@ export class AnalyticService {
       'Unsupported Hastic Server version',
       `Hastic Server at "${this._hasticDatasourceURL}" has unsupported version (got ${actual}, should be ${SUPPORTED_SERVER_VERSION})`,
     ]
-    this._displayConnectionAlert(HasticDatasourceAvailability.NOT_AVAILABLE, message);
+    this._displayConnectionAlert(HasticDatasourceStatus.NOT_AVAILABLE, message);
   }
 
   public get isUp(): boolean {
     return this._isUp;
   }
 
-  private _displayConnectionAlert(status: HasticDatasourceAvailability, message: string[]): void {
-    this.hasticDatasourceStatus.availability = status;
-    this.hasticDatasourceStatus.message = message.join('<br /> ');
+  private _displayConnectionAlert(status: HasticDatasourceStatus, message: string[]): void {
+    this.testingStatus.status = status;
+    this.testingStatus.message = message.join('<br /> ');
 
     const statusChanged = this._updateHasticUrlStatus(status);
 
@@ -419,7 +419,7 @@ export class AnalyticService {
    * Updates hastic datasource status
    * @returns true if status has been changed
    */
-  private _updateHasticUrlStatus(status: HasticDatasourceAvailability): boolean {
+  private _updateHasticUrlStatus(status: HasticDatasourceStatus): boolean {
     if(!window.hasOwnProperty('hasticDatasourcesAvailability')) {
       window.hasticDatasourcesAvailability = {};
     }

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -277,7 +277,6 @@ export class AnalyticService {
     this.testingStatus.message = 'Testing...';
 
     this._isUp = await this._isDatasourceAvailable();
-
     return this._isUp;
   }
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -399,7 +399,7 @@ export class AnalyticService {
 
   private _displayConnectionAlert(status: HasticDatasourceStatus, message: string[]): void {
     this.connectingStatus.status = status;
-    this.connectingStatus.message = message.join('<br /> ');
+    this.connectingStatus.message = message.join('<br />');
 
     const statusChanged = this._updateHasticUrlStatus(status);
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -27,18 +27,18 @@ export type TableTimeSeries = {
 export enum HasticDatasourceStatus {
   AVAILABLE = 'success',
   NOT_AVAILABLE = 'error',
-  TESTING = 'info'
+  CONNECTING = 'info'
 };
 
-export type HasticDatasourceTestingStatus = {
+export type HasticDatasourceConnectingStatus = {
   status: HasticDatasourceStatus,
   message: string
 }
 
 export class AnalyticService {
-  public testingStatus: HasticDatasourceTestingStatus = {
-    status: HasticDatasourceStatus.TESTING,
-    message: 'Testing...'
+  public connectingStatus: HasticDatasourceConnectingStatus = {
+    status: HasticDatasourceStatus.CONNECTING,
+    message: 'Connecting...'
   };
 
   private _isUp: boolean = false;
@@ -273,8 +273,8 @@ export class AnalyticService {
   }
 
   async checkDatasourceAvailability(): Promise<boolean> {
-    this.testingStatus.status = HasticDatasourceStatus.TESTING;
-    this.testingStatus.message = 'Testing...';
+    this.connectingStatus.status = HasticDatasourceStatus.CONNECTING;
+    this.connectingStatus.message = 'Connecting...';
 
     this._isUp = await this._isDatasourceAvailable();
     return this._isUp;
@@ -398,8 +398,8 @@ export class AnalyticService {
   }
 
   private _displayConnectionAlert(status: HasticDatasourceStatus, message: string[]): void {
-    this.testingStatus.status = status;
-    this.testingStatus.message = message.join('<br /> ');
+    this.connectingStatus.status = status;
+    this.connectingStatus.message = message.join('<br /> ');
 
     const statusChanged = this._updateHasticUrlStatus(status);
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -31,7 +31,7 @@ export enum HasticDatasourceAvailability {
 
 export type HasticDatasourceStatus = {
   testing: boolean,
-  availability: string,
+  availability: HasticDatasourceAvailability,
   message: string
 }
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -30,13 +30,13 @@ export enum HasticDatasourceStatus {
   CONNECTING = 'info'
 };
 
-export type HasticDatasourceConnectingStatus = {
+export type HasticDatasourceConnectionStatus = {
   status: HasticDatasourceStatus,
   message: string
 }
 
 export class AnalyticService {
-  public connectingStatus: HasticDatasourceConnectingStatus = {
+  public connectionStatus: HasticDatasourceConnectionStatus = {
     status: HasticDatasourceStatus.CONNECTING,
     message: 'Connecting...'
   };
@@ -273,8 +273,8 @@ export class AnalyticService {
   }
 
   async checkDatasourceAvailability(): Promise<boolean> {
-    this.connectingStatus.status = HasticDatasourceStatus.CONNECTING;
-    this.connectingStatus.message = 'Connecting...';
+    this.connectionStatus.status = HasticDatasourceStatus.CONNECTING;
+    this.connectionStatus.message = 'Connecting...';
 
     this._isUp = await this._isDatasourceAvailable();
     return this._isUp;
@@ -398,8 +398,8 @@ export class AnalyticService {
   }
 
   private _displayConnectionAlert(status: HasticDatasourceStatus, message: string[]): void {
-    this.connectingStatus.status = status;
-    this.connectingStatus.message = message.join('<br />');
+    this.connectionStatus.status = status;
+    this.connectionStatus.message = message.join('<br />');
 
     const statusChanged = this._updateHasticUrlStatus(status);
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -26,20 +26,19 @@ export type TableTimeSeries = {
 
 export enum HasticDatasourceStatus {
   AVAILABLE = 'success',
-  NOT_AVAILABLE = 'error'
+  NOT_AVAILABLE = 'error',
+  TESTING = 'info'
 };
 
 export type HasticDatasourceTestingStatus = {
-  testing: boolean,
   status: HasticDatasourceStatus,
   message: string
 }
 
 export class AnalyticService {
   public testingStatus: HasticDatasourceTestingStatus = {
-    testing: false,
-    status: HasticDatasourceStatus.NOT_AVAILABLE,
-    message: ''
+    status: HasticDatasourceStatus.TESTING,
+    message: 'Testing...'
   };
 
   private _isUp: boolean = false;
@@ -274,11 +273,11 @@ export class AnalyticService {
   }
 
   async checkDatasourceAvailability(): Promise<boolean> {
-    this.testingStatus.testing = true;
+    this.testingStatus.status = HasticDatasourceStatus.TESTING;
+    this.testingStatus.message = 'Testing...';
 
     this._isUp = await this._isDatasourceAvailable();
 
-    this.testingStatus.testing = false;
     return this._isUp;
   }
 

--- a/src/panel/graph_panel/services/analytic_service.ts
+++ b/src/panel/graph_panel/services/analytic_service.ts
@@ -15,7 +15,7 @@ import * as _ from 'lodash';
 
 
 declare global {
-  interface Window { hasticDatasourcesAvailability: { [key: string]: HasticDatasourceStatus } }
+  interface Window { hasticDatasourcesStatuses: { [key: string]: HasticDatasourceStatus } }
 }
 
 // TODO: TableTimeSeries is bad name
@@ -420,16 +420,16 @@ export class AnalyticService {
    * @returns true if status has been changed
    */
   private _updateHasticUrlStatus(status: HasticDatasourceStatus): boolean {
-    if(!window.hasOwnProperty('hasticDatasourcesAvailability')) {
-      window.hasticDatasourcesAvailability = {};
+    if(!window.hasOwnProperty('hasticDatasourcesStatuses')) {
+      window.hasticDatasourcesStatuses = {};
     }
-    if(!window.hasticDatasourcesAvailability.hasOwnProperty(this._hasticDatasourceURL)) {
-      window.hasticDatasourcesAvailability[this._hasticDatasourceURL] = status;
+    if(!window.hasticDatasourcesStatuses.hasOwnProperty(this._hasticDatasourceURL)) {
+      window.hasticDatasourcesStatuses[this._hasticDatasourceURL] = status;
       return true;
     }
-    if(window.hasticDatasourcesAvailability[this._hasticDatasourceURL] !== status) {
+    if(window.hasticDatasourcesStatuses[this._hasticDatasourceURL] !== status) {
       appEvents.emit('hastic-datasource-status-changed', this._hasticDatasourceURL);
-      window.hasticDatasourcesAvailability[this._hasticDatasourceURL] = status;
+      window.hasticDatasourcesStatuses[this._hasticDatasourceURL] = status;
       return true;
     }
     return false;


### PR DESCRIPTION
Closes #412 
Closes #414 

## Before
![image](https://user-images.githubusercontent.com/1989898/75346928-c1f88700-58b0-11ea-9fdc-37f588910ff9.png)

## After
![image](https://user-images.githubusercontent.com/1989898/75527425-f3459400-5a23-11ea-9ad9-834bb9fbaa4e.png)

![image](https://user-images.githubusercontent.com/1989898/75346827-94abd900-58b0-11ea-9cfc-b091da60873d.png)

## Changes
- add datasource-testing-like alert to the Analytics tab (copied from [Grafana 5.x sources](https://github.com/grafana/grafana/blob/653918056c594d7f56a65771b2c9681bdf8a3b9a/public/app/features/plugins/partials/ds_edit.html))
- remove the reconnect button from the Webhooks tab
- rename the reconnect button: "Reconnect to Hastic server" -> "Connect to Hastic Datasource"
- change the reconnect button color: gray -> blue