### PR TITLE
Cancel button color in analytic tab #423

### DIFF
--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -28,7 +28,7 @@
         ng-click="ctrl.createNew()"
       >
         <i class="fa fa-plus"></i>
-        Add Analytic Unit
+         &ensp;Add Analytic Unit
       </button>
     </div>
     <div class="gf-form-button-row" ng-if="ctrl.analyticsController.creatingNew">
@@ -50,7 +50,7 @@
         Saving
       </button>
       <button
-        class="btn btn-danger width-12"
+        class="btn btn-inverse width-12"
         ng-click="ctrl.cancelCreation()"
         ng-disabled="ctrl.analyticsController.saving"
       >

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -30,6 +30,23 @@
         <i class="fa fa-plus"></i>
          &ensp;Add Analytic Unit
       </button>
+      <button
+        ng-if="ctrl.analyticsController.analyticUnits.length > 0"
+        class="gf-form-label width-12 pointer"
+        style="display: inline;"
+        ng-click="ctrl.redetectAll()"
+      >
+        Re-detect all analytic units
+      </button>
+      <button
+        class="gf-form-label width-12 pointer"
+        style="display: inline;"
+        ng-click="ctrl.showHelp = !ctrl.showHelp"
+      >
+        Show Help
+        <i class="fa fa-caret-down" ng-show="ctrl.showHelp"></i>
+        <i class="fa fa-caret-right" ng-hide="ctrl.showHelp"></i>
+      </button>
     </div>
     <div class="gf-form-button-row" ng-if="ctrl.analyticsController.creatingNew">
       <button
@@ -56,16 +73,6 @@
       >
         <i class="fa fa-ban"></i>
         &ensp;Cancel
-      </button>
-    </div>
-    <div class="gf-form-button-row" ng-if="ctrl.analyticsController.analyticUnits.length > 0">
-      <button class="gf-form-label width-12 pointer" style="display: inline;" ng-click="ctrl.redetectAll()">
-        Re-detect all analytic units
-      </button>
-      <button class="gf-form-label width-12 pointer" style="display: inline;" ng-click="ctrl.showHelp = !ctrl.showHelp">
-        Show Help
-        <i class="fa fa-caret-down" ng-show="ctrl.showHelp"></i>
-        <i class="fa fa-caret-right" ng-hide="ctrl.showHelp"></i>
       </button>
     </div>
 

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -59,12 +59,10 @@
       </button>
     </div>
     <div class="gf-form-button-row" ng-if="ctrl.analyticsController.analyticUnits.length > 0">
-      <button class="gf-form-label width-12 pointer" ng-click="ctrl.redetectAll()">
+      <button class="gf-form-label width-12 pointer" style="display: inline;" ng-click="ctrl.redetectAll()">
         Re-detect all analytic units
       </button>
-    </div>
-    <div class="gf-form-button-row">
-      <button class="gf-form-label width-12 pointer" ng-click="ctrl.showHelp = !ctrl.showHelp">
+      <button class="gf-form-label width-12 pointer" style="display: inline;" ng-click="ctrl.showHelp = !ctrl.showHelp">
         Show Help
         <i class="fa fa-caret-down" ng-show="ctrl.showHelp"></i>
         <i class="fa fa-caret-right" ng-hide="ctrl.showHelp"></i>


### PR DESCRIPTION
Closes #423 
Closes #389 

This PR adds UI fixes in analytic tab.

## Changes:
- ### Add space between icon and "Add Analytic unit"
 #### Before:
![image](https://user-images.githubusercontent.com/39257464/76398404-df881f00-638d-11ea-90c0-3eeccccc9f30.png)

 #### After:
![image](https://user-images.githubusercontent.com/39257464/76398026-2f1a1b00-638d-11ea-99db-59ae97b6dbfc.png)

 - ### Change "cancel" button color from red to gray
 #### Before:
![image](https://user-images.githubusercontent.com/39257464/76398447-f3cc1c00-638d-11ea-9570-80ef9ba2c01e.png)

 #### After:
 ![image](https://user-images.githubusercontent.com/39257464/76397716-a56a4d80-638c-11ea-8440-d5759704da88.png)
 - ### "Add Analytic Unit", "Re-detect all analytic units" and "Show help" buttons in one line
 #### Before:
![image](https://user-images.githubusercontent.com/39257464/76400859-0e07f900-6392-11ea-87d6-df9b4fb64bcc.png)


 #### After:
![image](https://user-images.githubusercontent.com/39257464/76400117-d9477200-6390-11ea-8891-b6feaacf741c.png)

