### PR TITLE
Unavailable analytic units in Grafana v7.1.3

### DIFF
--- a/src/panel/graph_panel/partials/analytic_unit_7.x.html
+++ b/src/panel/graph_panel/partials/analytic_unit_7.x.html
@@ -16,7 +16,7 @@
         ng-model="analyticUnit.type"
         ng-options="type.value as type.name for type in ctrl.analyticUnitTypes[analyticUnit.detectorType]"
         ng-disabled="true"
-      />
+      ></select>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
       ng-model="analyticUnit.condition"
       ng-options="type for type in ctrl.analyticsController.conditions"
       ng-change="ctrl.onAnalyticUnitChange(analyticUnit)"
-    />
+    ></select>
     <input class="gf-form-input"
       ng-if="analyticUnit.condition !== 'NO_DATA'"
       type="number"
@@ -128,7 +128,7 @@
         ng-model="analyticUnit.seasonalityPeriod.unit"
         ng-change="ctrl.onSeasonalityChange(analyticUnit.id)"
         ng-options="type for type in ['seconds', 'minutes', 'hours', 'days', 'years']"
-      />
+      ></select>
     </div>
   </div>
 
@@ -142,7 +142,7 @@
         ng-model="analyticUnit.enableBounds"
         ng-change="ctrl.onAnalyticUnitChange(analyticUnit)"
         ng-options="bound.value as bound.name for bound in ctrl.boundTypes"
-      />
+      ></select>
     </div>
   </div>
 </div>

--- a/src/panel/graph_panel/partials/analytic_units_7.x.html
+++ b/src/panel/graph_panel/partials/analytic_units_7.x.html
@@ -83,7 +83,8 @@
       <select class="gf-form-input width-11" ng-if="analyticUnit.selected && !analyticUnit.saving"
         ng-model="ctrl.analyticsController.labelingMode"
         ng-options="type.value as type.name for type in analyticUnit.labelingModes"
-        ng-disabled="analyticUnit.status === 'LEARNING'" />
+        ng-disabled="analyticUnit.status === 'LEARNING'"
+      ></select>
 
       <button class="query-editor-row__action" ng-if="analyticUnit.selected && !analyticUnit.saving"
         bs-tooltip="'Cancel labeling'">

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -80,7 +80,6 @@
   </div>
 
   <div ng-if="ctrl.analyticsController.serverStatus === true && ctrl.analyticsController.loading">
-    <i class="fa fa-spinner fa-spin" > Fetching analytic units...</i>
+    <i class="fa fa-spinner fa-spin" > Fetching analytic units... </i>
   </div>
 </div>
-

--- a/src/panel/graph_panel/partials/tab_analytics.html
+++ b/src/panel/graph_panel/partials/tab_analytics.html
@@ -5,12 +5,12 @@
       ng-model="ctrl.panel.hasticDatasource"
       ng-options="ds.id as ds.name for ds in ctrl.hasticDatasources"
       ng-change="ctrl.onHasticDatasourceChange()"
-    />
+    ></select>
   </div>
 </div>
 
 <div>
-  <ng-include src="ctrl.partialsPath + '/reconnect_to_datasource.html'" />
+  <ng-include src="ctrl.partialsPath + '/reconnect_to_datasource.html'" ></ng-include>
 
   <div ng-if="ctrl.analyticsController.serverStatus === true && !ctrl.analyticsController.loading">
     <ng-include src="ctrl.getTemplatePath('analytic_units')">
@@ -80,7 +80,7 @@
   </div>
 
   <div ng-if="ctrl.analyticsController.serverStatus === true && ctrl.analyticsController.loading">
-    <i class="fa fa-spinner fa-spin" /> Fetching analytic units...
+    <i class="fa fa-spinner fa-spin" > Fetching analytic units...</i>
   </div>
 </div>
 


### PR DESCRIPTION
Closes #450 

This PR fixes the problem of missing `Add Analytic Unit` button.

## Problem:
HTML tags are not closed correctly, so nothing is rendered after `Select Hastic Datasource` in Grafan 7.1+

## Changes:
 - `<select />`, `<ng-include />`, `<i />`  tags -> `<select></select>` , `<ng-include></ng-include>`, `<i></i>` 
