### PR TITLE
fix saving sql analytics units

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -884,6 +884,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       if(datasource.access !== 'proxy') {
         throw new Error(`"${datasource.name}" datasource has "Browser" access type but only "Server" is supported`);
       }
+      this._datasourceRequest.datasourceId = datasource.id;
       this._datasourceRequest.type = datasource.type;
     }
     return this._datasourceRequest;

--- a/src/panel/graph_panel/models/datasource.ts
+++ b/src/panel/graph_panel/models/datasource.ts
@@ -1,4 +1,5 @@
 export type DatasourceRequest = {
+  datasourceId?: string;
   method: string,
   data: Object,
   params: Object,


### PR DESCRIPTION
This PR fixes error 400 on saving analytics unit with SQL datasource

**Changes**
send `datasourceId` additionally when saving analytic unit