### PR TITLE
WIP:  Grafana 7.2.x+ support #462 

### DIFF
--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -9,7 +9,7 @@ import { MetricExpanded } from './models/metric';
 import { DatasourceRequest } from './models/datasource';
 import { AnalyticUnitId, AnalyticUnit, LabelingMode } from './models/analytic_units/analytic_unit';
 import { BOUND_TYPES } from './models/analytic_units/anomaly_analytic_unit';
-import { AnalyticService, HasticDatasourceConnectionStatus } from './services/analytic_service';
+import { AnalyticService, HasticDatasourceConnectionStatus, HasticDatasourceStatus } from './services/analytic_service';
 import { AnalyticController } from './controllers/analytic_controller';
 import { HasticPanelInfo } from './models/hastic_panel_info';
 import { PanelTemplate, TemplateVariables } from './models/panel';
@@ -366,6 +366,9 @@ class GraphCtrl extends MetricsPanelCtrl {
   }
 
   get connectionStatus(): HasticDatasourceConnectionStatus {
+    if(this.analyticService === undefined) {
+      return { status: HasticDatasourceStatus.CONNECTING, message: 'Loading...' };
+    }
     return this.analyticService.connectionStatus;
   }
 

--- a/src/panel/graph_panel/graph_ctrl.ts
+++ b/src/panel/graph_panel/graph_ctrl.ts
@@ -273,17 +273,16 @@ class GraphCtrl extends MetricsPanelCtrl {
       this.refresh();
     });
 
-    appEvents.on('ds-request-response', data => {
-      let requestConfig = data.config;
+    // TODO: @types/grafana: add `getInspectorStream()` to `BackendSrv`
+    // @ts-ignore
+    if(this.backendSrv.getInspectorStream !== undefined) {
+    // @ts-ignore
+      this.backendSrv.getInspectorStream().subscribe({
+        next: this._updateDatasourceRequest.bind(this)
+      });
+    }
 
-      this._datasourceRequest = {
-        url: requestConfig.url,
-        method: requestConfig.method,
-        data: requestConfig.data,
-        params: requestConfig.params,
-        type: undefined
-      };
-    });
+    appEvents.on('ds-request-response', this._updateDatasourceRequest.bind(this));
 
     appEvents.on('hastic-datasource-status-changed', (url: string) => {
       if(url === this.analyticService.hasticDatasourceURL) {
@@ -854,6 +853,23 @@ class GraphCtrl extends MetricsPanelCtrl {
   onSeasonalityChange(id: AnalyticUnitId, value?: number) {
     this.analyticsController.updateSeasonality(id, value);
     this.refresh();
+  }
+
+  // TODO: response type
+  private _updateDatasourceRequest(response: any) {
+    let requestConfig = response.config;
+
+    if(requestConfig.hideFromInspector === true) {
+      return;
+    }
+
+    this._datasourceRequest = {
+      url: requestConfig.url,
+      method: requestConfig.method,
+      data: requestConfig.data,
+      params: requestConfig.params,
+      type: undefined
+    };
   }
 
   private async _updatePanelInfo() {


### PR DESCRIPTION
Closes #462 

This PR adds support for Grafana versions since 7.2.0

For now, only Graphite and Prometheus are tested. 
Graphite works, Prometheus doesn't (query seems to be changed a bit)

TODO:
- test if it works with multiple panels in a dashboard
- support the new Prometheus query type (in [tsdb-kit](https://github.com/CorpGlory/tsdb-kit))
- test other supported datasources
- display tsdb-kit errors in the panel (now it looks like nothing happened when datasource query fails)